### PR TITLE
Fix slug readthedocs-pr.yaml

### DIFF
--- a/.github/workflows/readthedocs-pr.yaml
+++ b/.github/workflows/readthedocs-pr.yaml
@@ -13,4 +13,4 @@ jobs:
     steps:
       - uses: readthedocs/actions/preview@v1
         with:
-          project-slug: "readthedocs-preview"
+          project-slug: "secml-torch"


### PR DESCRIPTION
Fix slug to pr preview docs --> secml-torch

<!-- readthedocs-preview readthedocs-preview start -->
----
📚 Documentation preview 📚: https://readthedocs-preview--64.org.readthedocs.build/en/64/

<!-- readthedocs-preview readthedocs-preview end -->