### PR TITLE
82 quantization constraint

### DIFF
--- a/docs/source/secmlt.tests.rst
+++ b/docs/source/secmlt.tests.rst
@@ -44,10 +44,26 @@ secmlt.tests.test\_constants module
    :undoc-members:
    :show-inheritance:
 
+secmlt.tests.test\_constraints module
+-------------------------------------
+
+.. automodule:: secmlt.tests.test_constraints
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 secmlt.tests.test\_data module
 ------------------------------
 
 .. automodule:: secmlt.tests.test_data
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+secmlt.tests.test\_manipulations module
+---------------------------------------
+
+.. automodule:: secmlt.tests.test_manipulations
    :members:
    :undoc-members:
    :show-inheritance:

--- a/src/secmlt/adv/evasion/modular_attack.py
+++ b/src/secmlt/adv/evasion/modular_attack.py
@@ -93,11 +93,35 @@ class ModularEvasionAttackFixedEps(BaseEvasionAttack):
 
         self.optimizer_cls = optimizer_cls
 
-        self.manipulation_function = manipulation_function
+        self._manipulation_function = manipulation_function
         self.initializer = initializer
         self.gradient_processing = gradient_processing
 
         super().__init__()
+
+    @property
+    def manipulation_function(self) -> Manipulation:
+        """
+        Get the manipulation function for the attack.
+
+        Returns
+        -------
+        Manipulation
+            The manipulation function used in the attack.
+        """
+        return self._manipulation_function
+
+    @manipulation_function.setter
+    def manipulation_function(self, manipulation_function: Manipulation) -> None:
+        """
+        Set the manipulation function for the attack.
+
+        Parameters
+        ----------
+        manipulation_function : Manipulation
+            The manipulation function to be used in the attack.
+        """
+        self._manipulation_function = manipulation_function
 
     @classmethod
     def get_perturbation_models(cls) -> set[str]:

--- a/src/secmlt/manipulations/manipulation.py
+++ b/src/secmlt/manipulations/manipulation.py
@@ -24,8 +24,42 @@ class Manipulation(ABC):
         perturbation_constraints : list[Constraint]
             Constraints for the perturbation (delta).
         """
-        self.domain_constraints = domain_constraints
-        self.perturbation_constraints = perturbation_constraints
+        self._domain_constraints = domain_constraints
+        self._perturbation_constraints = perturbation_constraints
+
+    @property
+    def domain_constraints(self) -> list[Constraint]:
+        """
+        Get the domain constraints for the manipulation.
+
+        Returns
+        -------
+        list[Constraint]
+            List of domain constraints for the manipulation.
+        """
+        return self._domain_constraints
+
+    @domain_constraints.setter
+    def domain_constraints(self, domain_constraints: list[Constraint]) -> None:
+        self._domain_constraints = domain_constraints
+
+    @property
+    def perturbation_constraints(self) -> list[Constraint]:
+        """
+        Get the perturbation constraints for the manipulation.
+
+        Returns
+        -------
+        list[Constraint]
+            List of perturbation constraints for the manipulation.
+        """
+        return self._perturbation_constraints
+
+    @perturbation_constraints.setter
+    def perturbation_constraints(
+        self, perturbation_constraints: list[Constraint]
+    ) -> None:
+        self._perturbation_constraints = perturbation_constraints
 
     def _apply_domain_constraints(self, x: torch.Tensor) -> torch.Tensor:
         for constraint in self.domain_constraints:

--- a/src/secmlt/optimization/constraints.py
+++ b/src/secmlt/optimization/constraints.py
@@ -301,7 +301,7 @@ class L0Constraint(LpConstraint):
         return proj.view_as(x)
 
 
-class QuantizationConstratint(Constraint):
+class QuantizationConstraint(Constraint):
     """Constraint for ensuring quantized outputs into specified levels."""
 
     def __init__(self, levels: int) -> None:

--- a/src/secmlt/optimization/constraints.py
+++ b/src/secmlt/optimization/constraints.py
@@ -294,8 +294,11 @@ class L0Constraint(LpConstraint):
             Samples projected onto L0 constraint.
         """
         flat_x = x.flatten(start_dim=1)
-        positions, topk = torch.topk(flat_x, k=int(self.radius))
-        return torch.zeros_like(flat_x).scatter_(positions, topk).reshape(x.shape)
+        _, topk_indices = torch.topk(flat_x.abs(), k=int(self.radius), dim=1)
+        # zero out all values and scatter the top k values back
+        proj = torch.zeros_like(flat_x)
+        proj.scatter_(1, topk_indices, flat_x.gather(1, topk_indices))
+        return proj.view_as(x)
 
 
 class QuantizationConstratint(Constraint):

--- a/src/secmlt/optimization/constraints.py
+++ b/src/secmlt/optimization/constraints.py
@@ -337,4 +337,5 @@ class QuantizationConstraint(Constraint):
             Input with values quantized on the specified
             number of levels.
         """
-        return (x * self.levels).round() / self.levels
+        # the -1 there is to count for the 0
+        return (x * (self.levels - 1)).round() / (self.levels - 1)

--- a/src/secmlt/tests/test_constraints.py
+++ b/src/secmlt/tests/test_constraints.py
@@ -6,7 +6,7 @@ from secmlt.optimization.constraints import (
     L1Constraint,
     L2Constraint,
     LInfConstraint,
-    QuantizationConstratint,
+    QuantizationConstraint,
 )
 
 
@@ -104,7 +104,7 @@ def test_l0_constraint_invalid_radius():
     ],
 )
 def test_quantization_constraint(x, levels, expected):
-    constraint = QuantizationConstratint(levels=levels)
+    constraint = QuantizationConstraint(levels=levels)
     projected = constraint(x)
     assert_tensor_equal(projected, expected)
 
@@ -112,4 +112,4 @@ def test_quantization_constraint(x, levels, expected):
 def test_quantization_constraint_invalid_levels():
     # test that passing a non-integer levels value raises an error
     with pytest.raises(ValueError):  # noqa: PT011
-        QuantizationConstratint(levels=2.5)
+        QuantizationConstraint(levels=2.5)

--- a/src/secmlt/tests/test_constraints.py
+++ b/src/secmlt/tests/test_constraints.py
@@ -93,12 +93,12 @@ def test_l0_constraint_invalid_radius():
     [
         (
             torch.tensor([[0.2, 0.7], [0.4, 0.8]]),
-            4,
+            5,
             torch.tensor([[0.25, 0.75], [0.5, 0.75]]),
         ),
         (
             torch.tensor([[0.1, 0.9], [0.3, 0.6]]),
-            2,
+            3,
             torch.tensor([[0.0, 1.0], [0.5, 0.5]]),
         ),
     ],

--- a/src/secmlt/tests/test_constraints.py
+++ b/src/secmlt/tests/test_constraints.py
@@ -1,0 +1,115 @@
+import pytest
+import torch
+from secmlt.optimization.constraints import (
+    ClipConstraint,
+    L0Constraint,
+    L1Constraint,
+    L2Constraint,
+    LInfConstraint,
+    QuantizationConstratint,
+)
+
+
+def assert_tensor_equal(actual, expected, msg="") -> None:
+    assert torch.allclose(
+        actual, expected
+    ), f"Expected {expected}, but got {actual}. {msg}"
+
+
+@pytest.mark.parametrize(
+    "lb, ub, x, expected",
+    [
+        (
+            0.0,
+            1.0,
+            torch.tensor([[1.5, -0.5], [0.3, 0.7]]),
+            torch.tensor([[1.0, 0.0], [0.3, 0.7]]),
+        ),
+        (
+            -1.0,
+            1.0,
+            torch.tensor([[1.5, -1.5], [0.3, 0.7]]),
+            torch.tensor([[1.0, -1.0], [0.3, 0.7]]),
+        ),
+    ],
+)
+def test_clip_constraint(lb, ub, x, expected):
+    constraint = ClipConstraint(lb=lb, ub=ub)
+    projected = constraint(x)
+    assert_tensor_equal(projected, expected)
+
+
+@pytest.mark.parametrize(
+    "constraint_class, radius, x, expected_norm, norm_type",
+    [
+        (L2Constraint, 5.0, torch.tensor([[3.0, 4.0], [0.5, 0.5]]), 5.0, 2),
+        (
+            LInfConstraint,
+            1.0,
+            torch.tensor([[3.0, -4.0], [0.5, 0.5]]),
+            1.0,
+            float("inf"),
+        ),
+        (L1Constraint, 2.0, torch.tensor([[2.0, 2.0], [1.0, -1.0]]), 2.0, 1),
+    ],
+)
+def test_lp_constraints(constraint_class, radius, x, expected_norm, norm_type):
+    constraint = constraint_class(radius=radius)
+    projected = constraint(x)
+
+    # calculate the norm for the projection and ensure it does not exceed the radius
+    norms = torch.norm(projected.flatten(start_dim=1), p=norm_type, dim=1)
+    assert torch.all(
+        norms <= expected_norm
+    ), f"{constraint_class.__name__} failed with norms {norms}"
+
+
+@pytest.mark.parametrize(
+    "x, k, expected",
+    [
+        (
+            torch.tensor([[-1.5, -0.5, 0.1, 2.0], [0.3, 0.7, 0.1, 1.0]]),
+            2,
+            torch.tensor([[-1.5, 0.0, 0.0, 2.0], [0.0, 0.7, 0.0, 1.0]]),
+        )
+    ],
+)
+def test_l0_constraint(x, k, expected):
+    constraint = L0Constraint(radius=k)
+    projected = constraint(x)
+
+    # top 2 values should remain, others should be zero
+    assert_tensor_equal(projected, expected)
+
+
+def test_l0_constraint_invalid_radius():
+    # Test that passing a non-integer radius raises an error
+    with pytest.raises(ValueError):  # noqa: PT011
+        L0Constraint(radius=2.5)
+
+
+@pytest.mark.parametrize(
+    "x, levels, expected",
+    [
+        (
+            torch.tensor([[0.2, 0.7], [0.4, 0.8]]),
+            4,
+            torch.tensor([[0.25, 0.75], [0.5, 0.75]]),
+        ),
+        (
+            torch.tensor([[0.1, 0.9], [0.3, 0.6]]),
+            2,
+            torch.tensor([[0.0, 1.0], [0.5, 0.5]]),
+        ),
+    ],
+)
+def test_quantization_constraint(x, levels, expected):
+    constraint = QuantizationConstratint(levels=levels)
+    projected = constraint(x)
+    assert_tensor_equal(projected, expected)
+
+
+def test_quantization_constraint_invalid_levels():
+    # test that passing a non-integer levels value raises an error
+    with pytest.raises(ValueError):  # noqa: PT011
+        QuantizationConstratint(levels=2.5)

--- a/src/secmlt/tests/test_manipulations.py
+++ b/src/secmlt/tests/test_manipulations.py
@@ -1,0 +1,97 @@
+import pytest
+import torch
+from secmlt.manipulations.manipulation import AdditiveManipulation
+from secmlt.optimization.constraints import Constraint
+
+
+class MockConstraint(Constraint):
+    def __init__(self, mock_return):
+        self.mock_return = mock_return
+
+    def __call__(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
+        return self.mock_return
+
+
+@pytest.fixture
+def input_tensor():
+    return torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+
+
+@pytest.fixture
+def delta_tensor():
+    return torch.tensor([[0.1, 0.2], [0.3, 0.4]])
+
+
+@pytest.fixture
+def domain_constraint():
+    return MockConstraint(torch.tensor([[0.5, 0.6], [0.7, 0.8]]))
+
+
+@pytest.fixture
+def perturbation_constraint():
+    return MockConstraint(torch.tensor([[0.1, 0.2], [0.3, 0.4]]))
+
+
+@pytest.fixture
+def additive_manipulation(domain_constraint, perturbation_constraint):
+    return AdditiveManipulation(
+        domain_constraints=[domain_constraint],
+        perturbation_constraints=[perturbation_constraint],
+    )
+
+
+def test_apply_domain_constraints(additive_manipulation, input_tensor):
+    # apply the domain constraint and check if it modifies the input correctly
+    result = additive_manipulation._apply_domain_constraints(input_tensor)
+    expected = torch.tensor([[0.5, 0.6], [0.7, 0.8]])
+    assert torch.equal(result, expected), f"Expected {expected}, got {result}"
+
+
+def test_apply_perturbation_constraints(additive_manipulation, delta_tensor):
+    # apply the perturbation constraint and check if it modifies the delta correctly
+    result = additive_manipulation._apply_perturbation_constraints(delta_tensor)
+    expected = torch.tensor([[0.1, 0.2], [0.3, 0.4]])
+    assert torch.equal(result, expected), f"Expected {expected}, got {result}"
+
+
+def test_additive_manipulation(additive_manipulation, input_tensor, delta_tensor):
+    # test the additive manipulation
+    x_adv, delta = additive_manipulation(input_tensor, delta_tensor)
+    expected_x_adv = torch.tensor([[0.5, 0.6], [0.7, 0.8]])
+    expected_delta = torch.tensor([[0.1, 0.2], [0.3, 0.4]])
+
+    assert torch.equal(x_adv, expected_x_adv), f"Expected {expected_x_adv}, got {x_adv}"
+    assert torch.equal(delta, expected_delta), f"Expected {expected_delta}, got {delta}"
+
+
+def test_getters_and_setters(
+    additive_manipulation, domain_constraint, perturbation_constraint
+):
+    # test getter for domain_constraints
+    domain_constraints = additive_manipulation.domain_constraints
+    assert domain_constraints == [
+        domain_constraint
+    ], f"Expected domain constraints {domain_constraint}, got {domain_constraints}"
+
+    # test setter for domain_constraints
+    new_domain_constraint = MockConstraint(torch.tensor([[0.0, 0.1], [0.2, 0.3]]))
+    additive_manipulation.domain_constraints = [new_domain_constraint]
+    assert additive_manipulation.domain_constraints == [
+        new_domain_constraint
+    ], "Domain constraints setter did not update correctly"
+
+    # test getter for perturbation_constraints
+    perturbation_constraints = additive_manipulation.perturbation_constraints
+    assert perturbation_constraints == [perturbation_constraint], (
+        f"Expected perturbation constraints {perturbation_constraint}, "
+        f"got {perturbation_constraints}"
+    )
+
+    # test setter for perturbation_constraints
+    new_perturbation_constraint = MockConstraint(
+        torch.tensor([[0.05, 0.15], [0.25, 0.35]])
+    )
+    additive_manipulation.perturbation_constraints = [new_perturbation_constraint]
+    assert additive_manipulation.perturbation_constraints == [
+        new_perturbation_constraint
+    ], "Perturbation constraints setter did not update correctly"


### PR DESCRIPTION
## Changelog

* Added getters and setters for domain and perturbation constraints into manipulations
* Added getters and setters for manipulation into attack
* Added quantization constraint
* Fixed bug in L0 norm projection

Fixes #82, #83 

<!-- readthedocs-preview secml-torch start -->
----
📚 Documentation preview 📚: https://secml-torch--85.org.readthedocs.build/en/85/

<!-- readthedocs-preview secml-torch end -->