### PR TITLE
approve after #104 - 105 step size is not passed to optimizer in modular attack

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,12 @@ The library can be installed together with other plugins that enable further fun
 
 * [Foolbox](https://github.com/bethgelab/foolbox), a Python toolbox to create adversarial examples.
 * [Tensorboard](https://www.tensorflow.org/tensorboard), a visualization toolkit for machine learning experimentation.
+* [Adversarial Library](https://github.com/jeromerony/adversarial-library), a powerful library of various adversarial attacks resources in PyTorch.
+
 
 Install one or more extras with the command:
 ```bash
-pip install secml-torch[foolbox,tensorboard]
-```
-
-To enable the `adv_lib` extra, you have to manually install the library from the original repository:
-
-```bash
-pip install git+https://github.com/jeromerony/adversarial-library
+pip install secml-torch[foolbox,tensorboard, adv_lib]
 ```
 
 ## Key Features

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
 pytest
 pytest-cov
 foolbox
-git+https://github.com/jeromerony/adversarial-library
+adv-lib

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
     extras_require={
         "foolbox": ["foolbox>=3.3.0"],
         "tensorboard": ["tensorboard"],
+        "adv_lib": ["adv_lib"],
     },
     python_requires=">=3.7",
 )

--- a/src/secmlt/adv/evasion/modular_attack.py
+++ b/src/secmlt/adv/evasion/modular_attack.py
@@ -148,7 +148,7 @@ class ModularEvasionAttackFixedEps(BaseEvasionAttack):
         raise NotImplementedError(msg)
 
     def _create_optimizer(self, delta: torch.Tensor, **kwargs) -> Optimizer:
-        return self.optimizer_cls([delta], **kwargs)
+        return self.optimizer_cls([delta], lr=self.step_size, **kwargs)
 
     def forward_loss(
         self, model: BaseModel, x: torch.Tensor, target: torch.Tensor
@@ -181,8 +181,10 @@ class ModularEvasionAttackFixedEps(BaseEvasionAttack):
         samples: torch.Tensor,
         labels: torch.Tensor,
         init_deltas: torch.Tensor = None,
-        **optim_kwargs,
+        optim_kwargs: dict | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
+        if optim_kwargs is None:
+            optim_kwargs = {}
         multiplier = 1 if self.y_target is not None else -1
         target = (
             torch.zeros_like(labels) + self.y_target
@@ -198,7 +200,7 @@ class ModularEvasionAttackFixedEps(BaseEvasionAttack):
             delta = self.initializer(samples.data)
         delta.requires_grad = True
 
-        optimizer = self._create_optimizer(delta, **optim_kwargs)
+        optimizer = self._create_optimizer(delta, optim_kwargs)
         x_adv, delta = self.manipulation_function(samples, delta)
         x_adv.data, delta.data = self.manipulation_function(samples.data, delta.data)
         best_losses = torch.zeros(samples.shape[0]).fill_(torch.inf)

--- a/src/secmlt/adv/evasion/modular_attack.py
+++ b/src/secmlt/adv/evasion/modular_attack.py
@@ -200,7 +200,7 @@ class ModularEvasionAttackFixedEps(BaseEvasionAttack):
             delta = self.initializer(samples.data)
         delta.requires_grad = True
 
-        optimizer = self._create_optimizer(delta, optim_kwargs)
+        optimizer = self._create_optimizer(delta, **optim_kwargs)
         x_adv, delta = self.manipulation_function(samples, delta)
         x_adv.data, delta.data = self.manipulation_function(samples.data, delta.data)
         best_losses = torch.zeros(samples.shape[0]).fill_(torch.inf)

--- a/src/secmlt/tests/test_constraints.py
+++ b/src/secmlt/tests/test_constraints.py
@@ -99,8 +99,13 @@ def test_l0_constraint_invalid_radius():
         ),
         (
             torch.tensor([[0.1, 0.9], [0.3, 0.6]]),
-            3,
-            torch.tensor([[0.0, 1.0], [0.5, 0.5]]),
+            torch.Tensor([0.1, 0.2, 0.5]),
+            torch.tensor([[0.1, 0.5], [0.2, 0.5]]),
+        ),
+        (
+            torch.tensor([[0.1, 0.9], [0.3, 0.6]]),
+            [0.1, 0.2, 0.5],
+            torch.tensor([[0.1, 0.5], [0.2, 0.5]]),
         ),
     ],
 )
@@ -114,6 +119,12 @@ def test_quantization_constraint_invalid_levels():
     # test that passing a non-integer levels value raises an error
     with pytest.raises(ValueError):  # noqa: PT011
         QuantizationConstraint(levels=2.5)
+
+
+def test_quantization_constraint_not_enough_levels():
+    # test that passing a number of levels < 2 values raises an error
+    with pytest.raises(ValueError):  # noqa: PT011
+        QuantizationConstraint(levels=1)
 
 
 @pytest.mark.parametrize(

--- a/src/secmlt/tests/test_manipulations.py
+++ b/src/secmlt/tests/test_manipulations.py
@@ -8,7 +8,7 @@ class MockConstraint(Constraint):
     def __init__(self, mock_return):
         self.mock_return = mock_return
 
-    def __call__(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
+    def _apply_constraint(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
         return self.mock_return
 
 


### PR DESCRIPTION
## Changelog

Approve after #104 

* Pass input learning rate to optimizer
* Refactor input optimizer kwargs for modular attack to be explicitly assigned to a dictionary rather than passed implicitly

Fixes #105, #106.

<!-- readthedocs-preview secml-torch start -->
----
📚 Documentation preview 📚: https://secml-torch--107.org.readthedocs.build/en/107/

<!-- readthedocs-preview secml-torch end -->