### PR TITLE
Bug fix: Projection on the l2 ball

### DIFF
--- a/src/secmlt/optimization/constraints.py
+++ b/src/secmlt/optimization/constraints.py
@@ -205,7 +205,9 @@ class L2Constraint(LpConstraint):
         """
         flat_x = x.flatten(start_dim=1)
         diff_norm = flat_x.norm(p=2, dim=1, keepdim=True).clamp_(min=1e-12)
-        flat_x = torch.where(diff_norm <= 1, flat_x, flat_x / diff_norm) * self.radius
+        flat_x = torch.where(
+            diff_norm <= self.radius, flat_x, self.radius * flat_x / diff_norm
+        )
         return flat_x.reshape(x.shape)
 
 


### PR DESCRIPTION
This version should handle the `self.radius < diff_norm < 1` and ` 1 < diff_norm < self.radius` cases

<!-- readthedocs-preview secml-torch start -->
----
📚 Documentation preview 📚: https://secml-torch--109.org.readthedocs.build/en/109/

<!-- readthedocs-preview secml-torch end -->