### PR TITLE
Fix link in contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ SecMLT is an open-source Python library for Adversarial Machine Learning and rob
 Before contributing to SecMLT:
 
 1. Familiarize yourself with the library by reviewing the [official documentation](https://secml-torch.readthedocs.io/en/latest/) and exploring the existing codebase.
-2. Install the required dependencies (refer to [the installation guide](https://secml-torch.readthedocs.io/en/latest/installation.html)).
+2. Install the required dependencies (refer to [the installation guide](https://secml-torch.readthedocs.io/en/latest/#installation)).
 
 ## Setting up your development environment
 


### PR DESCRIPTION
The installation guide link points to a 404. Fixed to point at the official docs.

<!-- readthedocs-preview secml-torch start -->
----
📚 Documentation preview 📚: https://secml-torch--114.org.readthedocs.build/en/114/

<!-- readthedocs-preview secml-torch end -->