### PR TITLE
Inclusion of Nevergrad backend as gradient-free optimization algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,12 @@ The library can be installed together with other plugins that enable further fun
 * [Foolbox](https://github.com/bethgelab/foolbox), a Python toolbox to create adversarial examples.
 * [Tensorboard](https://www.tensorflow.org/tensorboard), a visualization toolkit for machine learning experimentation.
 * [Adversarial Library](https://github.com/jeromerony/adversarial-library), a powerful library of various adversarial attacks resources in PyTorch.
+* [Nevergrad](https://facebookresearch.github.io/nevergrad/), a Python library providing several gradient-free optimization algorithms for black-box attacks.
 
 
 Install one or more extras with the command:
 ```bash
-pip install secml-torch[foolbox,tensorboard, adv_lib]
+pip install secml-torch[foolbox,tensorboard, adv_lib, nevergrad]
 ```
 
 ## Key Features

--- a/docs/source/secmlt.adv.evasion.rst
+++ b/docs/source/secmlt.adv.evasion.rst
@@ -10,6 +10,7 @@ Subpackages
    secmlt.adv.evasion.advlib_attacks
    secmlt.adv.evasion.aggregators
    secmlt.adv.evasion.foolbox_attacks
+   secmlt.adv.evasion.nevergrad_optim
 
 Submodules
 ----------
@@ -18,6 +19,14 @@ secmlt.adv.evasion.base\_evasion\_attack module
 -----------------------------------------------
 
 .. automodule:: secmlt.adv.evasion.base_evasion_attack
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+secmlt.adv.evasion.ga module
+----------------------------
+
+.. automodule:: secmlt.adv.evasion.ga
    :members:
    :undoc-members:
    :show-inheritance:

--- a/examples/ng_mnist_example.py
+++ b/examples/ng_mnist_example.py
@@ -20,18 +20,16 @@ print(f"test accuracy: {accuracy.item():.2f}")
 
 # Create and run attack
 epsilon = 1
-num_steps = 10
-step_size = 0.05
+num_steps = 100
 perturbation_model = LpPerturbationModels.LINF
 y_target = None
 
 native_attack = NevergradGeneticAlgorithm(
     perturbation_model=perturbation_model,
-    population_size=10,
+    population_size=30,
     epsilon=epsilon,
     num_steps=num_steps,
     budget=num_steps,
-    step_size=step_size,
     random_start=True,
     y_target=y_target,
 )

--- a/examples/ng_mnist_example.py
+++ b/examples/ng_mnist_example.py
@@ -1,5 +1,7 @@
 from loaders.get_loaders import get_mnist_loader
 from models.mnist_net import get_mnist_model
+from secmlt.adv.backends import Backends
+from secmlt.adv.evasion.ga import GeneticAlgorithm
 from secmlt.adv.evasion.nevergrad_optim.ng_attacks import NevergradGeneticAlgorithm
 from secmlt.adv.evasion.perturbation_models import LpPerturbationModels
 from secmlt.metrics.classification import Accuracy
@@ -24,7 +26,7 @@ num_steps = 100
 perturbation_model = LpPerturbationModels.LINF
 y_target = None
 
-native_attack = NevergradGeneticAlgorithm(
+native_attack = GeneticAlgorithm(
     perturbation_model=perturbation_model,
     population_size=30,
     epsilon=epsilon,
@@ -32,6 +34,7 @@ native_attack = NevergradGeneticAlgorithm(
     budget=num_steps,
     random_start=True,
     y_target=y_target,
+    backend=Backends.NEVERGRAD
 )
 
 native_adv_ds = native_attack(model, test_loader)

--- a/examples/ng_mnist_example.py
+++ b/examples/ng_mnist_example.py
@@ -2,7 +2,6 @@ from loaders.get_loaders import get_mnist_loader
 from models.mnist_net import get_mnist_model
 from secmlt.adv.backends import Backends
 from secmlt.adv.evasion.ga import GeneticAlgorithm
-from secmlt.adv.evasion.nevergrad_optim.ng_attacks import NevergradGeneticAlgorithm
 from secmlt.adv.evasion.perturbation_models import LpPerturbationModels
 from secmlt.metrics.classification import Accuracy
 from secmlt.models.pytorch.base_pytorch_nn import BasePytorchClassifier

--- a/examples/ng_mnist_example.py
+++ b/examples/ng_mnist_example.py
@@ -1,0 +1,43 @@
+from loaders.get_loaders import get_mnist_loader
+from models.mnist_net import get_mnist_model
+from secmlt.adv.evasion.nevergrad_optim.ng_attacks import NevergradGeneticAlgorithm
+from secmlt.adv.evasion.perturbation_models import LpPerturbationModels
+from secmlt.metrics.classification import Accuracy
+from secmlt.models.pytorch.base_pytorch_nn import BasePytorchClassifier
+
+device = "cpu"
+model_path = "example_data/models/mnist"
+dataset_path = "example_data/datasets/"
+net = get_mnist_model(model_path).to(device)
+test_loader = get_mnist_loader(dataset_path)
+
+# Wrap model
+model = BasePytorchClassifier(net)
+
+# Test accuracy on original data
+accuracy = Accuracy()(model, test_loader)
+print(f"test accuracy: {accuracy.item():.2f}")
+
+# Create and run attack
+epsilon = 1
+num_steps = 10
+step_size = 0.05
+perturbation_model = LpPerturbationModels.LINF
+y_target = None
+
+native_attack = NevergradGeneticAlgorithm(
+    perturbation_model=perturbation_model,
+    population_size=10,
+    epsilon=epsilon,
+    num_steps=num_steps,
+    budget=num_steps,
+    step_size=step_size,
+    random_start=True,
+    y_target=y_target,
+)
+
+native_adv_ds = native_attack(model, test_loader)
+
+# Test accuracy on adversarial examples
+n_robust_accuracy = Accuracy()(model, native_adv_ds)
+print("robust accuracy native: ", n_robust_accuracy)

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,3 +2,4 @@ pytest
 pytest-cov
 foolbox
 adv-lib
+nevergrad

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
         "foolbox": ["foolbox>=3.3.0"],
         "tensorboard": ["tensorboard"],
         "adv_lib": ["adv_lib"],
+        "nevergrad": ["nevergrad"]
     },
     python_requires=">=3.7",
 )

--- a/src/secmlt/adv/backends.py
+++ b/src/secmlt/adv/backends.py
@@ -7,3 +7,4 @@ class Backends:
     FOOLBOX = "foolbox"
     ADVLIB = "advlib"
     NATIVE = "native"
+    NEVERGRAD = "nevergrad"

--- a/src/secmlt/adv/evasion/base_evasion_attack.py
+++ b/src/secmlt/adv/evasion/base_evasion_attack.py
@@ -123,7 +123,7 @@ class BaseEvasionAttackCreator:
 
     @staticmethod
     @abstractmethod
-    def get_backends() -> set[str]:
+    def get_backends() -> list[str]:
         """
         Get the available backends for the given attack.
 

--- a/src/secmlt/adv/evasion/base_evasion_attack.py
+++ b/src/secmlt/adv/evasion/base_evasion_attack.py
@@ -188,6 +188,7 @@ class BaseEvasionAttack:
 
     @trackers.setter
     def trackers(self, trackers: list[TRACKER_TYPE] | None = None) -> None:
+        self._trackers = None
         if self._trackers_allowed():
             if trackers is not None and not isinstance(trackers, list):
                 trackers = [trackers]
@@ -247,8 +248,9 @@ class BaseEvasionAttack:
 
     @abstractmethod
     def _run(
-        self,
-        model: BaseModel,
-        samples: torch.Tensor,
-        labels: torch.Tensor,
-    ) -> torch.Tensor: ...
+            self,
+            model: BaseModel,
+            samples: torch.Tensor,
+            labels: torch.Tensor,
+    ) -> torch.Tensor:
+        ...

--- a/src/secmlt/adv/evasion/ga.py
+++ b/src/secmlt/adv/evasion/ga.py
@@ -1,0 +1,142 @@
+"""Implementation of Genetic Algorithm attack."""
+import importlib
+from typing import Optional
+
+from secmlt.adv.backends import Backends
+from secmlt.adv.evasion.base_evasion_attack import (
+    BaseEvasionAttack,
+    BaseEvasionAttackCreator,
+)
+from secmlt.trackers import Tracker
+
+
+class GeneticAlgorithm(BaseEvasionAttackCreator):
+    """Implementation of Genetic Algorithm."""
+
+    def __new__(
+            cls,
+            perturbation_model: str,
+            epsilon: float,
+            num_steps: int,
+            budget: Optional[int] = None,
+            population_size: int = 10,
+            random_start: bool = False,
+            y_target: int | None = None,
+            lb: float = 0.0,
+            ub: float = 1.0,
+            backend: str = Backends.NEVERGRAD,
+            trackers: list[Tracker] | None = None,
+            **kwargs,
+    ) -> BaseEvasionAttack:
+        """
+        Create the PGD attack.
+
+        Parameters
+        ----------
+        perturbation_model : str
+            Perturbation model for the attack. Available: 1, 2, inf.
+        epsilon : float
+            Radius of the constraint for the Lp ball.
+        num_steps : int
+            Maximum number of iterations for the attack.
+        budget : int, optional
+            Maximum number of queries.
+            Default None means that num_steps will be set.
+        population_size: int, optional
+            Number of variants created at each round of optimization.
+            Default 10.
+        random_start : bool, optional
+            Whether to use a random initialization onto the Lp ball, by
+            default False.
+        y_target : int | None, optional
+            Target label for a targeted attack, None
+            for untargeted attack, by default None.
+        lb : float, optional
+            Lower bound of the input space, by default 0.0.
+        ub : float, optional
+            Upper bound of the input space, by default 1.0.
+        backend : str, optional
+            Backend to use to run the attack, by default Backends.FOOLBOX
+        trackers : list[Tracker] | None, optional
+            Trackers to check various attack metrics (see secmlt.trackers),
+            available only for native implementation, by default None.
+
+        Returns
+        -------
+        BaseEvasionAttack
+            PGD attack instance.
+        """
+        cls.check_backend_available(backend)
+        implementation = cls.get_implementation(backend)
+        implementation.check_perturbation_model_available(perturbation_model)
+        return implementation(
+            perturbation_model=perturbation_model,
+            epsilon=epsilon,
+            num_steps=num_steps,
+            budget=budget,
+            population_size=population_size,
+            random_start=random_start,
+            y_target=y_target,
+            lb=lb,
+            ub=ub,
+            trackers=trackers,
+            **kwargs,
+        )
+
+    @staticmethod
+    def get_backends() -> list[str]:
+        """Get available implementations for the GA attack."""
+        return [Backends.NEVERGRAD]
+
+    @classmethod
+    def get_implementation(cls, backend: str) -> "BaseEvasionAttack":
+        """
+        Get the implementation of the attack with the given backend.
+
+        Parameters
+        ----------
+        backend : str
+            The backend for the attack. See secmlt.adv.backends for
+            available backends.
+
+        Returns
+        -------
+        BaseEvasionAttack
+            Attack implementation.
+        """
+        implementations = {
+            Backends.NEVERGRAD: cls.get_foolbox_implementation,
+        }
+        cls.check_backend_available(backend)
+        return implementations[backend]()
+
+    @classmethod
+    def get_nevergrad_implementation(cls) -> "BaseEvasionAttack":
+        """
+        Get the Foolbox implementation of the attack.
+
+        Returns
+        -------
+        BaseEvasionAttack
+            Foolbox implementation of the attack.
+
+        Raises
+        ------
+        ImportError
+            Raises ImportError if Foolbox extra is not installed.
+        """
+        if importlib.util.find_spec("nevergrad", None) is not None:
+            return cls._get_nevergrad_implementation()
+        msg = "Nevergrad extra not installed."
+        raise ImportError(msg)
+
+    @staticmethod
+    def _get_nevergrad_implementation() -> type["PGDFoolbox"]:  # noqa: F821
+        if importlib.util.find_spec("nevergrad", None) is not None:
+            from secmlt.adv.evasion.nevergrad_optim.ng_attacks import (
+                NevergradGeneticAlgorithm,
+            )
+
+            return NevergradGeneticAlgorithm
+        msg = "Nevergrad extra not installed"
+        raise ImportError(msg)

--- a/src/secmlt/adv/evasion/ga.py
+++ b/src/secmlt/adv/evasion/ga.py
@@ -105,7 +105,7 @@ class GeneticAlgorithm(BaseEvasionAttackCreator):
             Attack implementation.
         """
         implementations = {
-            Backends.NEVERGRAD: cls.get_foolbox_implementation,
+            Backends.NEVERGRAD: cls.get_nevergrad_implementation,
         }
         cls.check_backend_available(backend)
         return implementations[backend]()

--- a/src/secmlt/adv/evasion/modular_attack.py
+++ b/src/secmlt/adv/evasion/modular_attack.py
@@ -200,6 +200,8 @@ class ModularEvasionAttackFixedEps(BaseEvasionAttack):
         losses = self.loss_function(scores, target)
         return scores, losses
 
+
+
     def _run(
             self,
             model: BaseModel,

--- a/src/secmlt/adv/evasion/nevergrad_optim/__init__.py
+++ b/src/secmlt/adv/evasion/nevergrad_optim/__init__.py
@@ -1,0 +1,6 @@
+"""Wrappers of Nevergrad for evasion attacks."""
+
+import importlib.util
+
+if importlib.util.find_spec("nevergrad", None) is not None:
+    from .ng_modular_attack import *  # noqa: F403

--- a/src/secmlt/adv/evasion/nevergrad_optim/ng_attacks.py
+++ b/src/secmlt/adv/evasion/nevergrad_optim/ng_attacks.py
@@ -32,10 +32,9 @@ class NevergradGeneticAlgorithm(NgModularEvasionAttackFixedEps):
             lb: float = 0.0,
             ub: float = 1.0,
             trackers: list[Tracker] | None = None,
-            **kwargs,
     ) -> None:
         """
-        Create Native PGD attack.
+        Create Nevergrad Genetic Algorithm attack.
 
         Parameters
         ----------

--- a/src/secmlt/adv/evasion/nevergrad_optim/ng_attacks.py
+++ b/src/secmlt/adv/evasion/nevergrad_optim/ng_attacks.py
@@ -64,7 +64,9 @@ class NevergradGeneticAlgorithm(NgModularEvasionAttackFixedEps):
             LpPerturbationModels.L2: L2Constraint,
             LpPerturbationModels.LINF: LInfConstraint,
         }
-
+        if perturbation_model not in perturbation_models:
+            msg = f"Perturbation model {perturbation_model} not yet implemented."
+            raise NotImplementedError(msg)
         if random_start:
             initializer = RandomLpInitializer(
                 perturbation_model=perturbation_model,
@@ -92,3 +94,19 @@ class NevergradGeneticAlgorithm(NgModularEvasionAttackFixedEps):
             trackers=trackers,
             budget=budget
         )
+
+    @classmethod
+    def get_perturbation_models(cls) -> set[str]:
+        """
+        Check if a given perturbation model is implemented.
+
+        Returns
+        -------
+        set[str]
+            Set of perturbation models available for this attack.
+        """
+        return {
+            LpPerturbationModels.L1,
+            LpPerturbationModels.L2,
+            LpPerturbationModels.LINF,
+        }

--- a/src/secmlt/adv/evasion/nevergrad_optim/ng_attacks.py
+++ b/src/secmlt/adv/evasion/nevergrad_optim/ng_attacks.py
@@ -1,0 +1,95 @@
+"""Genetic algorithm to compute evasion attacks with nevergrad."""
+from secmlt.adv.evasion import LpPerturbationModels
+from secmlt.adv.evasion.modular_attack import CE_LOSS
+from secmlt.adv.evasion.nevergrad_optim import NgModularEvasionAttackFixedEps
+from secmlt.adv.evasion.nevergrad_optim.ng_initializer import NevergradInitializer
+from secmlt.adv.evasion.nevergrad_optim.ng_optimizer_factory import (
+    NevergradOptimizerFactory,
+)
+from secmlt.manipulations.manipulation import AdditiveManipulation
+from secmlt.optimization.constraints import (
+    ClipConstraint,
+    L1Constraint,
+    L2Constraint,
+    LInfConstraint,
+)
+from secmlt.optimization.initializer import Initializer, RandomLpInitializer
+from secmlt.trackers import Tracker
+
+
+class NevergradGeneticAlgorithm(NgModularEvasionAttackFixedEps):
+    """Create a genetic algorithm with nevergrad."""
+
+    def __init__(
+            self,
+            perturbation_model: LpPerturbationModels,
+            epsilon: float,
+            num_steps: int,
+            budget: int,
+            population_size: int,
+            random_start: bool,
+            y_target: int | None = None,
+            lb: float = 0.0,
+            ub: float = 1.0,
+            trackers: list[Tracker] | None = None,
+            **kwargs,
+    ) -> None:
+        """
+        Create Native PGD attack.
+
+        Parameters
+        ----------
+        perturbation_model : str
+            Perturbation model for the attack. Available: 1, 2, inf.
+        epsilon : float
+            Radius of the constraint for the Lp ball.
+        num_steps : int
+            Number of iterations for the attack.
+        budget : int
+            Amount of query budget
+        random_start : bool
+            Whether to use a random initialization onto the Lp ball.
+        y_target : int | None, optional
+            Target label for a targeted attack, None
+            for untargeted attack, by default None.
+        lb : float, optional
+            Lower bound of the input space, by default 0.0.
+        ub : float, optional
+            Upper bound of the input space, by default 1.0.
+        trackers : list[Tracker] | None, optional
+            Trackers to check various attack metrics (see secmlt.trackers),
+            available only for native implementation, by default None.
+        """
+        perturbation_models = {
+            LpPerturbationModels.L1: L1Constraint,
+            LpPerturbationModels.L2: L2Constraint,
+            LpPerturbationModels.LINF: LInfConstraint,
+        }
+
+        if random_start:
+            initializer = RandomLpInitializer(
+                perturbation_model=perturbation_model,
+                radius=epsilon,
+            )
+        else:
+            initializer = Initializer()
+        initializer = NevergradInitializer(initializer, lb=lb, ub=ub)
+        self.epsilon = epsilon
+        perturbation_constraints = [
+            perturbation_models[perturbation_model](radius=self.epsilon),
+        ]
+        domain_constraints = [ClipConstraint(lb=lb, ub=ub)]
+        manipulation_function = AdditiveManipulation(
+            domain_constraints=domain_constraints,
+            perturbation_constraints=perturbation_constraints,
+        )
+        super().__init__(
+            y_target=y_target,
+            num_steps=num_steps,
+            loss_function=CE_LOSS,
+            optimizer_cls=NevergradOptimizerFactory.create_ga(population_size=population_size),
+            manipulation_function=manipulation_function,
+            initializer=initializer,
+            trackers=trackers,
+            budget=budget
+        )

--- a/src/secmlt/adv/evasion/nevergrad_optim/ng_initializer.py
+++ b/src/secmlt/adv/evasion/nevergrad_optim/ng_initializer.py
@@ -1,0 +1,45 @@
+"""Initializer for the manipulation in Nevergrad."""
+import nevergrad
+import torch
+from secmlt.optimization.initializer import Initializer
+
+
+class NevergradInitializer(Initializer):
+    """Initialize manipulation by wrapping the requirements of nevergrad."""
+
+    def __init__(self, initializer: Initializer, lb: float = 0, ub: float = 0) -> None:
+        """
+        Create the manipulation to use in nevergrad.
+
+        Parameters
+        ----------
+        initializer : Initializer
+            the initialization to apply
+        lb : float = 0.0
+            lower bound for initialization
+        ub : float = 1
+            upper bound for initialization
+        """
+        self.initializer = initializer
+        self.ub = ub
+        self.lb = lb
+        super().__init__()
+
+    def __call__(self, x: torch.Tensor, **kwargs) -> nevergrad.p.Array:
+        """
+        Create the initialization.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            the sample from which compute the manipulation.
+
+        Returns
+        -------
+        nevergrad.p.Array
+            the initialized delta.
+        """
+        init_delta = self.initializer(x)
+        delta = nevergrad.p.Array(shape=init_delta.shape, lower=-self.ub, upper=self.ub)
+        delta.value = init_delta.numpy()
+        return delta

--- a/src/secmlt/adv/evasion/nevergrad_optim/ng_modular_attack.py
+++ b/src/secmlt/adv/evasion/nevergrad_optim/ng_modular_attack.py
@@ -62,7 +62,8 @@ class NgModularEvasionAttackFixedEps(ModularEvasionAttackFixedEps):
                          optimizer_cls=optimizer_cls,
                          manipulation_function=manipulation_function,
                          initializer=initializer,
-                         gradient_processing=NoGradientProcessing(), budget=budget,
+                         gradient_processing=NoGradientProcessing(),
+                         budget=budget,
                          trackers=trackers,
                          step_size=0)
 

--- a/src/secmlt/adv/evasion/nevergrad_optim/ng_modular_attack.py
+++ b/src/secmlt/adv/evasion/nevergrad_optim/ng_modular_attack.py
@@ -113,7 +113,10 @@ class NgModularEvasionAttackFixedEps(ModularEvasionAttackFixedEps):
         torch.Tensor, torch.Tensor
             the manipulated sample and the manipulation itself
         """
-        p_delta = torch.from_numpy(delta.value)
+        if not isinstance(delta, torch.Tensor):
+            p_delta = torch.from_numpy(delta.value).float()
+        else:
+            p_delta = delta.data
         x_adv, _ = self.manipulation_function(x.data, p_delta)
         return x_adv, delta
 

--- a/src/secmlt/adv/evasion/nevergrad_optim/ng_modular_attack.py
+++ b/src/secmlt/adv/evasion/nevergrad_optim/ng_modular_attack.py
@@ -1,0 +1,90 @@
+"""Modular iterative attacks with customizable components with nevergrad."""
+
+import nevergrad
+import torch
+from nevergrad.parametrization.core import Parameter
+from secmlt.adv.evasion.modular_attack import ModularEvasionAttackFixedEps
+from secmlt.models.base_model import BaseModel
+from secmlt.optimization.constraints import ClipConstraint
+from torch.optim import Optimizer
+from torch.utils.data import DataLoader, TensorDataset
+
+
+class NgModularEvasionAttackFixedEps(ModularEvasionAttackFixedEps):
+    """Modular evasion attack for fixed-epsilon attacks, using nevergrad as backend."""
+
+    def _optimizer_step(
+            self, optimizer: nevergrad.optimization.base.Optimizer,
+            delta: nevergrad.p.Array,
+            loss: torch.Tensor
+    ) -> Parameter:
+        """
+        Perform the optimization step to optimize the attack.
+
+        Parameters
+        ----------
+        optimizer : nevergrad.optimization.base.Optimizer
+            The optimizer used by the attack
+        delta : nevergrad.p.Array
+            The manipulation computed by the attack
+        loss : torch.Tensor
+            The loss computed by the attack for the provided delta
+
+        Returns
+        -------
+        nevergrad.p.Array
+            Resulting manipulation after the optimization step
+        """
+        optimizer.tell(delta, loss.item())
+        return optimizer.ask()
+
+    def _apply_manipulation(
+            self, x: torch.Tensor, delta: nevergrad.p.Array
+    ) -> (torch.Tensor, torch.Tensor):
+        p_delta = torch.from_numpy(delta.value)
+        return self.manipulation_function(x.data, p_delta)
+
+    def _create_optimizer(self, delta: nevergrad.p.Array, **kwargs) -> Optimizer:
+        constraints = self.manipulation_function.domain_constraints
+        upper, lower = 1, 0
+        if constraints is not None:
+            for constraint in constraints:
+                if isinstance(constraint, ClipConstraint):
+                    upper, lower = max(upper, constraint.ub), min(lower, constraint.lb)
+        return self.optimizer_cls(
+            parametrization=nevergrad.p.Array(
+                shape=delta.value.shape, lower=lower, upper=upper)
+        )
+
+    def __call__(self, model: BaseModel, data_loader: DataLoader) -> DataLoader:
+        """
+        Compute the attack against the model, using the input data.
+
+        Parameters
+        ----------
+        model : BaseModel
+            Model to test.
+        data_loader : DataLoader
+            Test dataloader.
+
+        Returns
+        -------
+        DataLoader
+            Dataloader with adversarial examples and original labels.
+        """
+        adversarials = []
+        original_labels = []
+        for samples, labels in data_loader:
+            for sample, label in zip(samples, labels, strict=False):
+                sample = sample.unsqueeze(0)
+                label = label.unsqueeze(0)
+                x_adv, _ = self._run(model, sample, label)
+                adversarials.append(x_adv)
+                original_labels.append(label)
+        adversarials = torch.vstack(adversarials)
+        original_labels = torch.vstack(original_labels)
+        adversarial_dataset = TensorDataset(adversarials, original_labels)
+        return DataLoader(
+            adversarial_dataset,
+            batch_size=data_loader.batch_size,
+        )

--- a/src/secmlt/adv/evasion/nevergrad_optim/ng_optimizer_factory.py
+++ b/src/secmlt/adv/evasion/nevergrad_optim/ng_optimizer_factory.py
@@ -46,7 +46,7 @@ class NevergradOptimizerFactory:
         return NevergradOptimizerFactory.create(optimizer_name, **kwargs)
 
     @staticmethod
-    def create(optim_cls: Union[str, ClassVar[ConfiguredOptimizer]],
+    def create(optim_cls: Union[str, type[ConfiguredOptimizer]],
                **optimizer_args) -> ConfiguredOptimizer:
         """
         Create a Nevergrad optimization algorithm.
@@ -74,7 +74,7 @@ class NevergradOptimizerFactory:
         raise ValueError(msg)
 
     @staticmethod
-    def create_ga(population_size: int = 10, crossover: str = "twopoints",
+    def create_ga(population_size: int = 10, crossover: str = "onepoint",
                   **kwargs) -> ConfiguredOptimizer:
         """
         Create a Differential Evolution (genetic algorithm) using Nevergrad as backend.

--- a/src/secmlt/adv/evasion/nevergrad_optim/ng_optimizer_factory.py
+++ b/src/secmlt/adv/evasion/nevergrad_optim/ng_optimizer_factory.py
@@ -1,0 +1,102 @@
+"""Factory for creating nevergrad optimization algorithms."""
+
+from functools import partial
+from typing import ClassVar, Union
+
+from nevergrad.optimization.base import ConfiguredOptimizer
+from nevergrad.optimization.differentialevolution import DifferentialEvolution
+
+GA = "ga"
+
+
+class NevergradOptimizerFactory:
+    """Factory for creating optimization algorithms using nevergrad."""
+
+    NG_OPTIMIZERS: ClassVar[dict[str, ConfiguredOptimizer]] = {
+        GA: DifferentialEvolution,
+    }
+
+    @staticmethod
+    def create_from_name(
+            optimizer_name: str,
+            **kwargs,
+    ) -> ConfiguredOptimizer:
+        """
+        Create a Nevergrad optimization algorithm by name.
+
+        Available: "ga" -> Differential Evolution.
+
+        Parameters
+        ----------
+        optimizer_name : str
+            The name of the optjmizer to create.
+            Available: "ga"
+
+        Returns
+        -------
+        Optimizer
+            the created optimizer.
+
+        Raises
+        ------
+        ValueError
+            Raises ValueError when the requested optimizer is not in the list
+            of implemented optimizers.
+        """
+        return NevergradOptimizerFactory.create(optimizer_name, **kwargs)
+
+    @staticmethod
+    def create(optim_cls: Union[str, ClassVar[ConfiguredOptimizer]],
+               **optimizer_args) -> ConfiguredOptimizer:
+        """
+        Create a Nevergrad optimization algorithm.
+
+        Use its name among the available or the class itself.
+        Check the nevergrad documentation for more options
+        (https://facebookresearch.github.io/nevergrad/optimizers_ref.html).
+
+        Parameters
+        ----------
+        optim_cls : Union[str, ClassVar[ConfiguredOptimizer]]
+            a string or a nevergrad optimizer class to instantiate
+
+        Returns
+        -------
+        ConfiguredOptimizer :
+            the created optimizer.
+        """
+        if not isinstance(optim_cls, str):
+            return partial(optim_cls, **optimizer_args)()
+        if optim_cls == "ga":
+            return NevergradOptimizerFactory.create_ga(**optimizer_args)
+        msg = f"Optimizer not found. Use one of: \
+                    {list(NevergradOptimizerFactory.NG_OPTIMIZERS.keys())}"
+        raise ValueError(msg)
+
+    @staticmethod
+    def create_ga(population_size: int = 10, crossover: str = "twopoints",
+                  **kwargs) -> ConfiguredOptimizer:
+        """
+        Create a Differential Evolution (genetic algorithm) using Nevergrad as backend.
+
+        Check the nevergrad documentation for more options
+        (https://facebookresearch.github.io/nevergrad/optimizers_ref.html#nevergrad.families.DifferentialEvolution).
+
+        Parameters
+        ----------
+        population_size : int = 10
+            the amount of sampling applied to determine the
+            direction to take while optimizing
+        crossover : str = "twopoints"
+            define the merging strategy for the crossover.
+            Default is "twopoints".
+
+        Returns
+        -------
+        DifferentialEvolution :
+            the created optimizer.
+
+        """
+        return DifferentialEvolution(popsize=population_size,
+                                     crossover=crossover,
+                                     **kwargs)

--- a/src/secmlt/adv/evasion/pgd.py
+++ b/src/secmlt/adv/evasion/pgd.py
@@ -192,4 +192,5 @@ class PGDNative(ModularEvasionAttackFixedEps):
             gradient_processing=gradient_processing,
             initializer=initializer,
             trackers=trackers,
+            budget=2*num_steps
         )

--- a/src/secmlt/optimization/constraints.py
+++ b/src/secmlt/optimization/constraints.py
@@ -112,10 +112,10 @@ class LpConstraint(Constraint, ABC):
     """Abstract class for Lp constraint."""
 
     def __init__(
-        self,
-        radius: float = 0.0,
-        center: float = 0.0,
-        p: str = LpPerturbationModels.LINF,
+            self,
+            radius: float = 0.0,
+            center: float = 0.0,
+            p: str = LpPerturbationModels.LINF,
     ) -> None:
         """
         Create Lp constraint.
@@ -354,9 +354,9 @@ class QuantizationConstraint(InputSpaceConstraint):
     """Constraint for ensuring quantized outputs into specified levels."""
 
     def __init__(
-        self,
-        preprocessing: DataProcessing = None,
-        levels: Union[list[float], torch.Tensor, int] = 255,
+            self,
+            preprocessing: DataProcessing = None,
+            levels: Union[list[float], torch.Tensor, int] = 255,
     ) -> None:
         """
         Create the QuantizationConstraint.
@@ -388,10 +388,10 @@ class QuantizationConstraint(InputSpaceConstraint):
             msg = "Levels must be an integer, list, or torch.Tensor."
             raise TypeError(msg)
         # sort levels to ensure they are in ascending order
-        self.levels = self.levels.sort().values
+        self.levels = self.levels.sort().values # noqa: PD011
         super().__init__(preprocessing)
 
-    def _apply_constraint(self, x: torch.Tensor) -> torch.Tensor:
+    def _apply_constraint(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
         # reshape x to facilitate broadcasting with custom levels
         x_expanded = x.unsqueeze(-1)
         # calculate the absolute difference between x and each custom level
@@ -417,7 +417,7 @@ class MaskConstraint(Constraint):
         self.mask = mask.type(torch.bool)
         super().__init__()
 
-    def _apply_constraint(self, x: torch.Tensor) -> torch.Tensor:
+    def _apply_constraint(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
         """
         Enforce the mask constraint.
 

--- a/src/secmlt/optimization/gradient_processing.py
+++ b/src/secmlt/optimization/gradient_processing.py
@@ -47,6 +47,26 @@ class GradientProcessing(ABC):
         ...
 
 
+class NoGradientProcessing(GradientProcessing):
+    """Absence of processing."""
+
+    def __call__(self, grad: torch.Tensor) -> torch.Tensor:
+        """
+        Gradient is not processed.
+
+        Parameters
+        ----------
+        grad : torch.Tensor
+            Input gradients.
+
+        Returns
+        -------
+        torch.Tensor
+            The unaltered gradient.
+        """
+        return grad
+
+
 class LinearProjectionGradientProcessing(GradientProcessing):
     """Linear projection of the gradient onto Lp balls."""
 

--- a/src/secmlt/optimization/optimizer_factory.py
+++ b/src/secmlt/optimization/optimizer_factory.py
@@ -25,6 +25,7 @@ class OptimizerFactory:
         **kwargs,
     ) -> functools.partial[Adam] | functools.partial[SGD]:
         """
+
         Create an optimizer.
 
         Parameters
@@ -44,6 +45,7 @@ class OptimizerFactory:
         ValueError
             Raises ValueError when the requested optimizer is not in the list
             of implemented optimizers.
+
         """
         if optimizer_name == ADAM:
             return OptimizerFactory.create_adam(lr)
@@ -56,6 +58,7 @@ class OptimizerFactory:
     @staticmethod
     def create_adam(lr: float) -> functools.partial[Adam]:
         """
+
         Create the Adam optimizer.
 
         Parameters
@@ -67,6 +70,7 @@ class OptimizerFactory:
         -------
         functools.partial[Adam]
             Adam optimizer.
+
         """
         return functools.partial(Adam, lr=lr)
 

--- a/src/secmlt/tests/test_attacks.py
+++ b/src/secmlt/tests/test_attacks.py
@@ -1,5 +1,4 @@
 import pytest
-from secmlt.adv.backends import Backends
 from secmlt.adv.evasion.advlib_attacks.advlib_pgd import PGDAdvLib
 from secmlt.adv.evasion.base_evasion_attack import BaseEvasionAttack
 from secmlt.adv.evasion.foolbox_attacks.foolbox_pgd import PGDFoolbox

--- a/src/secmlt/tests/test_attacks.py
+++ b/src/secmlt/tests/test_attacks.py
@@ -1,7 +1,10 @@
 import pytest
+from secmlt.adv.backends import Backends
 from secmlt.adv.evasion.advlib_attacks.advlib_pgd import PGDAdvLib
 from secmlt.adv.evasion.base_evasion_attack import BaseEvasionAttack
 from secmlt.adv.evasion.foolbox_attacks.foolbox_pgd import PGDFoolbox
+from secmlt.adv.evasion.ga import GeneticAlgorithm
+from secmlt.adv.evasion.nevergrad_optim.ng_attacks import NevergradGeneticAlgorithm
 from secmlt.adv.evasion.perturbation_models import LpPerturbationModels
 from secmlt.adv.evasion.pgd import PGD, PGDNative
 from torch.utils.data import DataLoader
@@ -17,31 +20,31 @@ from torch.utils.data import DataLoader
 )
 @pytest.mark.parametrize(
     (
-        "backend",
-        "perturbation_models",
+            "backend",
+            "perturbation_models",
     ),
     [
         (
-            "foolbox",
-            PGDFoolbox.get_perturbation_models(),
+                "foolbox",
+                PGDFoolbox.get_perturbation_models(),
         ),
         (
-            "advlib",
-            PGDAdvLib.get_perturbation_models(),
+                "advlib",
+                PGDAdvLib.get_perturbation_models(),
         ),
         (
-            "native",
-            PGDNative.get_perturbation_models(),
+                "native",
+                PGDNative.get_perturbation_models(),
         ),
     ],
 )
 def test_pgd_attack(
-    backend,
-    perturbation_models,
-    random_start,
-    y_target,
-    model,
-    data_loader,
+        backend,
+        perturbation_models,
+        random_start,
+        y_target,
+        model,
+        data_loader,
 ) -> BaseEvasionAttack:
     for perturbation_model in LpPerturbationModels.pert_models:
         if perturbation_model in perturbation_models:
@@ -57,7 +60,7 @@ def test_pgd_attack(
             assert isinstance(attack(model, data_loader), DataLoader)
         else:
             with pytest.raises(NotImplementedError):
-                attack = PGD(
+                PGD(
                     perturbation_model=perturbation_model,
                     epsilon=0.5,
                     num_steps=10,
@@ -65,4 +68,59 @@ def test_pgd_attack(
                     random_start=random_start,
                     y_target=y_target,
                     backend=backend,
+                )
+
+
+@pytest.mark.parametrize(
+    "random_start",
+    [True, False],
+)
+@pytest.mark.parametrize(
+    "y_target",
+    [None, 1],
+)
+@pytest.mark.parametrize(
+    (
+            "backend",
+            "perturbation_models",
+    ),
+    [
+        (
+                "nevergrad",
+                NevergradGeneticAlgorithm.get_perturbation_models(),
+        ),
+    ],
+)
+def test_ga_attack(
+        backend,
+        perturbation_models,
+        random_start,
+        y_target,
+        model,
+        data_loader,
+) -> BaseEvasionAttack:
+    for perturbation_model in LpPerturbationModels.pert_models:
+        if perturbation_model in perturbation_models:
+            attack = GeneticAlgorithm(
+                perturbation_model=perturbation_model,
+                epsilon=0.5,
+                num_steps=10,
+                budget=10,
+                population_size=3,
+                random_start=random_start,
+                y_target=y_target,
+                backend=backend
+            )
+            assert isinstance(attack(model, data_loader), DataLoader)
+        else:
+            with pytest.raises(NotImplementedError):
+                GeneticAlgorithm(
+                    perturbation_model=perturbation_model,
+                    epsilon=0.5,
+                    num_steps=10,
+                    budget=10,
+                    population_size=3,
+                    random_start=random_start,
+                    y_target=y_target,
+                    backend=backend
                 )


### PR DESCRIPTION
# Inclusion of Nevergrad

This pull requests changes the inner loop of evasion attacks in order to extend them to gradient-free optimizers as well.
There are few changes that must be viewed before approval:

1) **the inclusion of `budget` parameter:** now attacks have `num_steps` but also `budget`, which can differ. The first is the maximum number of iterations given to the attack, the other is the consumed budget (forward + backward). Now, budget is OPTIONAL, and it is `2*num_steps` for PGD and `num_steps` for GeneticAlgorithm.
**Please double check this, and ask for rework in case it does not match the requirements.**

2) **Base loop is modified:** to use other optimization algorithms, all Pytorch-specific commands are included into methods that can be overwritten.

3) **Trackers are tracking gradient after the processing:** to realize point number 2, the tracker takes the gradient after the processing. **Please double check this, and ask for rework in case it does not match the requirements.**

4) **Nevergrad is not compatible with trackers yet:** since it works sample-wise, the default is that nevergrad components have trackers disabled.
