### PR TITLE
added support for attacking an ensemble of models with loss averaging

### DIFF
--- a/src/secmlt/adv/evasion/base_evasion_attack.py
+++ b/src/secmlt/adv/evasion/base_evasion_attack.py
@@ -2,7 +2,7 @@
 
 import importlib.util
 from abc import abstractmethod
-from typing import Literal
+from typing import Literal, Union
 
 import torch
 from secmlt.adv.backends import Backends
@@ -144,14 +144,14 @@ class BaseEvasionAttackCreator:
 class BaseEvasionAttack:
     """Base class for evasion attacks."""
 
-    def __call__(self, model: BaseModel, data_loader: DataLoader) -> DataLoader:
+    def __call__(self, model: Union[BaseModel, list[BaseModel]], data_loader: DataLoader) -> DataLoader:
         """
         Compute the attack against the model, using the input data.
 
         Parameters
         ----------
-        model : BaseModel
-            Model to test.
+        model : BaseModel | list[BaseModel]
+            Model or list of models to test.
         data_loader : DataLoader
             Test dataloader.
 


### PR DESCRIPTION
## Initial support for evasion attacks Model ensembles

This pull request changes the inner loop of the evasion attack to support ensembles by passing a list of models. The attack computes gradients on the average of losses of each model.