### PR TITLE
Add dropout to fix batch size mismatch and device mismatch in modular_attack

### DIFF
--- a/src/secmlt/adv/evasion/modular_attack.py
+++ b/src/secmlt/adv/evasion/modular_attack.py
@@ -232,14 +232,14 @@ class ModularEvasionAttackFixedEps(BaseEvasionAttack):
 
             # keep perturbation with highest loss
             best_delta.data = torch.where(
-                atleast_kd(losses.detach().cpu() < best_losses, len(samples.shape)),
-                delta.data,
-                best_delta.data,
+                atleast_kd(losses.detach().cpu() < best_losses.detach().cpu(), len(samples.shape)),
+                delta.detach().cpu().data,
+                best_delta.detach().cpu().data,
             )
             best_losses.data = torch.where(
-                losses.detach().cpu() < best_losses,
+                losses.detach().cpu() < best_losses.detach().cpu(),
                 losses.detach().cpu(),
-                best_losses.data,
+                best_losses.detach().cpu().data,
             )
-        x_adv, _ = self.manipulation_function(samples.data, best_delta.data)
+        x_adv, _ = self.manipulation_function(samples.detach().cpu().data, best_delta.data)
         return x_adv, best_delta

--- a/src/secmlt/trackers/trackers.py
+++ b/src/secmlt/trackers/trackers.py
@@ -68,6 +68,10 @@ class Tracker(ABC):
         torch.Tensor
             History of tracked parameters.
         """
+        # Dropout of the last batch element if there is a size mismatch
+        reference_size = self.tracked[0].size()
+        if self.tracked[-1].size() != reference_size:
+            self.tracked.pop()
         return torch.stack(self.tracked, -1)
 
     def get_last_tracked(self) -> Union[None, torch.Tensor]:


### PR DESCRIPTION
Add dropout to fix batch size mismatch and device mismatch in modular_attack
Error can be reproduced when using PGD attack.

<!-- readthedocs-preview secml-torch start -->
----
📚 Documentation preview 📚: https://secml-torch--113.org.readthedocs.build/en/113/

<!-- readthedocs-preview secml-torch end -->