### PR TITLE
Add first draft of base_jailbreak

### DIFF
--- a/src/secmlt/adv/jailbreak/__init__.py
+++ b/src/secmlt/adv/jailbreak/__init__.py
@@ -1,0 +1,1 @@
+"""Jailbreak attacks."""

--- a/src/secmlt/adv/jailbreak/base_jailbreak_attack.py
+++ b/src/secmlt/adv/jailbreak/base_jailbreak_attack.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from typing import Any
     from secmlt.models.base_language_model import BaseLanguageModel
 
 
@@ -85,7 +85,7 @@ class BaseJailbreakAttack:
         objective: Objective,
     ) -> bool:
         """
-        Check whether the generated adversarial prompt constitutes a successful jailbreak.
+        Check whether the generated adversarial prompt is a successful jailbreak.
 
         Parameters
         ----------

--- a/src/secmlt/adv/jailbreak/base_jailbreak_attack.py
+++ b/src/secmlt/adv/jailbreak/base_jailbreak_attack.py
@@ -1,0 +1,108 @@
+"""Base classes for implementing attacks and wrapping backends."""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import TYPE_CHECKING, Callable
+
+if TYPE_CHECKING:
+    from typing import Any
+    from secmlt.models.base_language_model import BaseLanguageModel
+
+
+Objective = Callable[..., Any] | None
+
+
+class BaseJailbreakAttack:
+    """Base class for jailbreak attacks."""
+
+    def __call__(
+        self,
+        model: BaseLanguageModel,
+        behaviors: list[dict[str, Any]],
+        objective: Objective = None,
+    ) -> list[tuple[str, dict[str, Any]]]:
+        """
+        Compute the jailbreak attack against the model, using the input behaviors.
+
+        Parameters
+        ----------
+        model : BaseLanguageModel
+            Victim language model to attack.
+        behaviors : list of dict
+            List of behavior specifications. Each element represents
+            a single behavior to jailbreak.
+        objective : callable or None, optional
+            Optional objective used by the attack (e.g., loss, judge, score).
+            If not required by the attack, it can be None.
+
+        Returns
+        -------
+        list of tuples
+            List of (adv_prompt, logs) pairs, one for each behavior.
+        """
+        results: list[tuple[str, dict[str, Any]]] = []
+        for behavior in behaviors:
+            adv_prompt, logs = self._run(model, behavior, objective)
+            results.append((adv_prompt, logs))
+        return results
+
+    @abstractmethod
+    def _run(
+        self,
+        model: BaseLanguageModel,
+        behavior: dict[str, Any],
+        objective: Objective,
+    ) -> tuple[str, dict[str, Any]]:
+        """
+        Run the jailbreak attack on a single behavior.
+
+        Parameters
+        ----------
+        model : BaseLanguageModel
+            Victim language model.
+        behavior : dict
+            Behavior specification to jailbreak.
+        objective : callable or None
+            Optional objective used internally by the attack.
+
+        Returns
+        -------
+        adv_prompt : str
+            Generated adversarial prompt for the behavior.
+        logs : dict
+            Dictionary containing attack-specific logs and metadata.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def is_jailbreak(
+        self,
+        model: BaseLanguageModel,
+        behavior: dict[str, Any],
+        adv_prompt: str,
+        logs: dict[str, Any],
+        objective: Objective,
+    ) -> bool:
+        """
+        Check whether the generated adversarial prompt constitutes a successful jailbreak.
+
+        Parameters
+        ----------
+        model : BaseLanguageModel
+            Victim language model.
+        behavior : dict
+            Original behavior specification.
+        adv_prompt : str
+            Generated adversarial prompt.
+        logs : dict
+            Logs produced during the attack.
+        objective : callable or None
+            Optional objective used by the attack.
+
+        Returns
+        -------
+        bool
+            True if the attack is considered successful, False otherwise.
+        """
+        raise NotImplementedError

--- a/src/secmlt/adv/jailbreak/base_jailbreak_attack.py
+++ b/src/secmlt/adv/jailbreak/base_jailbreak_attack.py
@@ -3,24 +3,41 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from secmlt.models.base_language_model import BaseLanguageModel
 
-
-Objective = Callable[..., Any] | None
+    IS_JAILBREAK_TYPE = Callable[
+        [BaseLanguageModel, dict[str, Any], str, dict[str, Any]],
+        bool,
+    ]
 
 
 class BaseJailbreakAttack:
     """Base class for jailbreak attacks."""
 
+    def __init__(
+        self,
+        is_jailbreak: IS_JAILBREAK_TYPE | None = None,
+    ) -> None:
+        """
+        Create a jailbreak attack.
+
+        Parameters
+        ----------
+        is_jailbreak : callable or None, optional
+            Success criterion used by the attack, by default None.
+        """
+        self._is_jailbreak = is_jailbreak
+
     def __call__(
         self,
         model: BaseLanguageModel,
         behaviors: list[dict[str, Any]],
-        objective: Objective = None,
+        objectives: list[str] | None = None,
     ) -> list[tuple[str, dict[str, Any]]]:
         """
         Compute the jailbreak attack against the model, using the input behaviors.
@@ -32,19 +49,23 @@ class BaseJailbreakAttack:
         behaviors : list of dict
             List of behavior specifications. Each element represents
             a single behavior to jailbreak.
-        objective : callable or None, optional
-            Optional objective used by the attack (e.g., loss, judge, score).
-            If not required by the attack, it can be None.
+        objectives : list of str or None, optional
+            Optional objectives used by the attack, one for each behavior
+            (e.g., target prefixes such as "Sure, here is"), by default None.
 
         Returns
         -------
         list of tuples
             List of (adv_prompt, logs) pairs, one for each behavior.
         """
-        results: list[tuple[str, dict[str, Any]]] = []
-        for behavior in behaviors:
-            adv_prompt, logs = self._run(model, behavior, objective)
-            results.append((adv_prompt, logs))
+        if objectives is not None and len(objectives) != len(behaviors):
+            msg = "Objectives and behaviors must have the same length."
+            raise ValueError(msg)
+
+        results = []
+        for i, behavior in enumerate(behaviors):
+            objective = None if objectives is None else objectives[i]
+            results.append(self._run(model, behavior, objective))
         return results
 
     @abstractmethod
@@ -52,7 +73,7 @@ class BaseJailbreakAttack:
         self,
         model: BaseLanguageModel,
         behavior: dict[str, Any],
-        objective: Objective,
+        objective: str | None = None,
     ) -> tuple[str, dict[str, Any]]:
         """
         Run the jailbreak attack on a single behavior.
@@ -63,26 +84,24 @@ class BaseJailbreakAttack:
             Victim language model.
         behavior : dict
             Behavior specification to jailbreak.
-        objective : callable or None
-            Optional objective used internally by the attack.
+        objective : str or None, optional
+            Optional objective used by the attack for the behavior, by default None.
 
         Returns
         -------
         adv_prompt : str
-            Generated adversarial prompt for the behavior.
+            Generated adversarial prompt.
         logs : dict
-            Dictionary containing attack-specific logs and metadata.
+            Attack logs.
         """
         raise NotImplementedError
 
-    @abstractmethod
     def is_jailbreak(
         self,
         model: BaseLanguageModel,
         behavior: dict[str, Any],
         adv_prompt: str,
         logs: dict[str, Any],
-        objective: Objective,
     ) -> bool:
         """
         Check whether the generated adversarial prompt is a successful jailbreak.
@@ -97,12 +116,13 @@ class BaseJailbreakAttack:
             Generated adversarial prompt.
         logs : dict
             Logs produced during the attack.
-        objective : callable or None
-            Optional objective used by the attack.
 
         Returns
         -------
         bool
             True if the attack is considered successful, False otherwise.
         """
-        raise NotImplementedError
+        if self._is_jailbreak is None:
+            msg = "Jailbreak success criterion not available."
+            raise NotImplementedError(msg)
+        return self._is_jailbreak(model, behavior, adv_prompt, logs)

--- a/src/secmlt/metrics/classification.py
+++ b/src/secmlt/metrics/classification.py
@@ -1,10 +1,14 @@
 """Classification metrics for machine-learning models and for attack performance."""
 
-from typing import Union
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, Union
 
 import torch
 from secmlt.models.base_model import BaseModel
 from torch.utils.data import DataLoader
+
+if TYPE_CHECKING:
+    from secmlt.models.base_language_model import BaseLanguageModel
 
 
 def accuracy(y_pred: torch.Tensor, y_true: torch.Tensor) -> torch.Tensor:
@@ -23,7 +27,7 @@ def accuracy(y_pred: torch.Tensor, y_true: torch.Tensor) -> torch.Tensor:
     torch.Tensor
         The percentage of predictions that match the targets.
     """
-    return (y_pred.type(y_true.dtype) == y_true).mean()
+    return (y_pred.type(y_true.dtype) == y_true).float().mean()
 
 
 class Accuracy:
@@ -164,3 +168,70 @@ class EnsembleSuccessRate(AccuracyEnsemble):
         if self.y_target is None:
             return 1 - super()._compute()
         return super()._compute()
+
+
+class JailbreakAccuracy(Accuracy):
+    """Accuracy of a jailbreak success criterion."""
+
+    def __init__(
+        self,
+        is_jailbreak: Callable[
+            ["BaseLanguageModel", dict[str, Any], str, dict[str, Any]],
+            bool,
+        ],
+    ) -> None:
+        """
+        Create a jailbreak accuracy metric.
+
+        Parameters
+        ----------
+        is_jailbreak : callable
+            Function returning True when an adversarial prompt is a jailbreak.
+            This can wrap a judge model, string matcher, logit probe, or
+            latent-space probe.
+        """
+        super().__init__()
+        self.is_jailbreak = is_jailbreak
+
+    def __call__(
+        self,
+        model: "BaseLanguageModel",
+        behaviors: list[dict[str, Any]],
+        attack_results: list[tuple[str, dict[str, Any]]],
+    ) -> torch.Tensor:
+        """
+        Compute jailbreak accuracy on a batch of attack results.
+
+        Parameters
+        ----------
+        model : BaseLanguageModel
+            Victim language model.
+        behaviors : list of dict
+            Original behavior specifications.
+        attack_results : list of tuples
+            List of (adv_prompt, logs) pairs returned by a jailbreak attack.
+
+        Returns
+        -------
+        torch.Tensor
+            Fraction of prompts judged as successful jailbreaks.
+        """
+        if len(behaviors) != len(attack_results):
+            msg = "Behaviors and attack results must have the same length."
+            raise ValueError(msg)
+        if len(behaviors) == 0:
+            msg = "Cannot compute jailbreak accuracy on an empty batch."
+            raise ValueError(msg)
+
+        y_pred = torch.tensor(
+            [
+                self.is_jailbreak(model, behavior, adv_prompt, logs)
+                for behavior, (adv_prompt, logs) in zip(
+                    behaviors, attack_results, strict=True
+                )
+            ],
+            dtype=torch.bool,
+        )
+        y_true = torch.ones_like(y_pred)
+        self._accumulate(y_pred, y_true)
+        return self._compute()

--- a/src/secmlt/tests/test_jailbreaks.py
+++ b/src/secmlt/tests/test_jailbreaks.py
@@ -1,0 +1,44 @@
+import pytest
+from secmlt.adv.jailbreak.base_jailbreak_attack import BaseJailbreakAttack
+
+
+class DummyAttack(BaseJailbreakAttack):
+    def _run(self, model, behavior, objective=None):
+        return "adv_prompt", {}
+
+    def is_jailbreak(self, model, behavior, adv_prompt, logs, objective=None):
+        return True
+
+
+def test_base_jailbreak_call_returns_list(mock_hf_lm):
+    attack = DummyAttack()
+
+    behaviors = [
+        {"BehaviorID": "0", "Behavior": "test", "ContextString": ""},
+        {"BehaviorID": "1", "Behavior": "test2", "ContextString": ""},
+    ]
+
+    out = attack(mock_hf_lm, behaviors)
+
+    assert isinstance(out, list)
+    assert len(out) == len(behaviors)
+
+
+def test_base_jailbreak_call_returns_tuple_elements(mock_hf_lm):
+    attack = DummyAttack()
+
+    behaviors = [{"BehaviorID": "0", "Behavior": "test", "ContextString": ""}]
+    out = attack(mock_hf_lm, behaviors)
+
+    adv_prompt, logs = out[0]
+    assert isinstance(adv_prompt, str)
+    assert isinstance(logs, dict)
+
+
+def test_base_jailbreak_base_raises_if_not_implemented(mock_hf_lm):
+    attack = BaseJailbreakAttack()
+
+    behaviors = [{"BehaviorID": "0", "Behavior": "test", "ContextString": ""}]
+
+    with pytest.raises(NotImplementedError):
+        attack(mock_hf_lm, behaviors)

--- a/src/secmlt/tests/test_jailbreaks.py
+++ b/src/secmlt/tests/test_jailbreaks.py
@@ -2,20 +2,41 @@ import pytest
 from secmlt.adv.jailbreak.base_jailbreak_attack import BaseJailbreakAttack
 
 
+def dummy_is_jailbreak(_model, _behavior, _adv_prompt, logs):
+    return logs["success"]
+
+
 class DummyAttack(BaseJailbreakAttack):
+    def __init__(self):
+        super().__init__(is_jailbreak=dummy_is_jailbreak)
+        self.run_calls = 0
+
+    def _run(self, model, behavior, objective=None):
+        self.run_calls += 1
+        return "adv_prompt", {"success": behavior["success"], "objective": objective}
+
+
+class DummyAttackWithoutCriterion(BaseJailbreakAttack):
     def _run(self, model, behavior, objective=None):
         return "adv_prompt", {}
-
-    def is_jailbreak(self, model, behavior, adv_prompt, logs, objective=None):
-        return True
 
 
 def test_base_jailbreak_call_returns_list(mock_hf_lm):
     attack = DummyAttack()
 
     behaviors = [
-        {"BehaviorID": "0", "Behavior": "test", "ContextString": ""},
-        {"BehaviorID": "1", "Behavior": "test2", "ContextString": ""},
+        {
+            "BehaviorID": "0",
+            "Behavior": "test",
+            "ContextString": "",
+            "success": True,
+        },
+        {
+            "BehaviorID": "1",
+            "Behavior": "test2",
+            "ContextString": "",
+            "success": False,
+        },
     ]
 
     out = attack(mock_hf_lm, behaviors)
@@ -27,12 +48,103 @@ def test_base_jailbreak_call_returns_list(mock_hf_lm):
 def test_base_jailbreak_call_returns_tuple_elements(mock_hf_lm):
     attack = DummyAttack()
 
-    behaviors = [{"BehaviorID": "0", "Behavior": "test", "ContextString": ""}]
+    behaviors = [
+        {
+            "BehaviorID": "0",
+            "Behavior": "test",
+            "ContextString": "",
+            "success": True,
+        },
+    ]
     out = attack(mock_hf_lm, behaviors)
 
     adv_prompt, logs = out[0]
     assert isinstance(adv_prompt, str)
     assert isinstance(logs, dict)
+
+
+def test_base_jailbreak_call_runs_each_behavior(mock_hf_lm):
+    attack = DummyAttack()
+
+    behaviors = [
+        {
+            "BehaviorID": "0",
+            "Behavior": "test",
+            "ContextString": "",
+            "success": True,
+        },
+        {
+            "BehaviorID": "1",
+            "Behavior": "test2",
+            "ContextString": "",
+            "success": False,
+        },
+    ]
+    attack(mock_hf_lm, behaviors)
+
+    assert attack.run_calls == len(behaviors)
+
+
+def test_base_jailbreak_forwards_objectives(mock_hf_lm):
+    attack = DummyAttack()
+
+    behaviors = [
+        {
+            "BehaviorID": "0",
+            "Behavior": "test",
+            "ContextString": "",
+            "success": True,
+        },
+        {
+            "BehaviorID": "1",
+            "Behavior": "test2",
+            "ContextString": "",
+            "success": False,
+        },
+    ]
+    objectives = ["Sure, here is", "Absolutely, here are"]
+
+    out = attack(mock_hf_lm, behaviors, objectives=objectives)
+
+    assert [logs["objective"] for _, logs in out] == objectives
+
+
+def test_base_jailbreak_raises_on_mismatched_objectives(mock_hf_lm):
+    attack = DummyAttack()
+
+    behaviors = [
+        {
+            "BehaviorID": "0",
+            "Behavior": "test",
+            "ContextString": "",
+            "success": True,
+        },
+    ]
+
+    with pytest.raises(ValueError, match="same length"):
+        attack(mock_hf_lm, behaviors, objectives=["objective", "extra"])
+
+
+def test_base_jailbreak_uses_configured_success_criterion(mock_hf_lm):
+    attack = DummyAttack()
+
+    behavior = {
+        "BehaviorID": "0",
+        "Behavior": "test",
+        "ContextString": "",
+        "success": True,
+    }
+    out = attack(mock_hf_lm, [behavior])
+    adv_prompt, logs = out[0]
+
+    assert attack.is_jailbreak(mock_hf_lm, behavior, adv_prompt, logs)
+
+
+def test_base_jailbreak_raises_without_success_criterion(mock_hf_lm):
+    attack = DummyAttackWithoutCriterion()
+
+    with pytest.raises(NotImplementedError):
+        attack.is_jailbreak(mock_hf_lm, {}, "adv_prompt", {})
 
 
 def test_base_jailbreak_base_raises_if_not_implemented(mock_hf_lm):

--- a/src/secmlt/tests/test_metrics.py
+++ b/src/secmlt/tests/test_metrics.py
@@ -1,10 +1,27 @@
+import pytest
 import torch
 from secmlt.metrics.classification import (
     Accuracy,
     AccuracyEnsemble,
     AttackSuccessRate,
     EnsembleSuccessRate,
+    JailbreakAccuracy,
+    accuracy,
 )
+
+
+def always_jailbreak(*_args):
+    return True
+
+
+def test_accuracy_function() -> None:
+    y_pred = torch.tensor([True, False])
+    y_true = torch.tensor([True, True])
+
+    acc = accuracy(y_pred, y_true)
+
+    assert torch.is_tensor(acc)
+    assert acc == torch.tensor(0.5)
 
 
 def test_accuracy(model, data_loader) -> None:
@@ -29,3 +46,62 @@ def test_ensemble_success_rate(model, adv_loaders):
     ensemble_acc = EnsembleSuccessRate()
     acc = ensemble_acc(model, adv_loaders)
     assert torch.is_tensor(acc)
+
+
+def test_jailbreak_accuracy(mock_hf_lm):
+    class DummyAttack:
+        def is_jailbreak(self, model, behavior, adv_prompt, logs):
+            return logs["success"]
+
+    behaviors = [
+        {"BehaviorID": "0", "Behavior": "test", "ContextString": ""},
+        {"BehaviorID": "1", "Behavior": "test2", "ContextString": ""},
+    ]
+    attack_results = [
+        ("adv_prompt", {"success": True}),
+        ("adv_prompt", {"success": False}),
+    ]
+    attack = DummyAttack()
+    metric = JailbreakAccuracy(is_jailbreak=attack.is_jailbreak)
+
+    acc = metric(mock_hf_lm, behaviors, attack_results)
+
+    assert isinstance(metric, Accuracy)
+    assert torch.is_tensor(acc)
+    assert acc == torch.tensor(0.5)
+
+
+def test_jailbreak_accuracy_uses_logged_success_without_judge(mock_hf_lm):
+    class DummyAttack:
+        def is_jailbreak(self, model, behavior, adv_prompt, logs):
+            return logs["is_jailbreak"]
+
+    behaviors = [
+        {"BehaviorID": "0", "Behavior": "test", "ContextString": ""},
+        {"BehaviorID": "1", "Behavior": "test2", "ContextString": ""},
+    ]
+    attack_results = [
+        ("adv_prompt", {"is_jailbreak": True}),
+        ("adv_prompt", {"is_jailbreak": False}),
+    ]
+    attack = DummyAttack()
+    metric = JailbreakAccuracy(is_jailbreak=attack.is_jailbreak)
+
+    acc = metric(mock_hf_lm, behaviors, attack_results)
+
+    assert torch.is_tensor(acc)
+    assert acc == torch.tensor(0.5)
+
+
+def test_jailbreak_accuracy_raises_on_mismatched_batches(mock_hf_lm):
+    metric = JailbreakAccuracy(is_jailbreak=always_jailbreak)
+
+    with pytest.raises(ValueError, match="same length"):
+        metric(mock_hf_lm, [], [("adv_prompt", {})])
+
+
+def test_jailbreak_accuracy_raises_on_empty_batch(mock_hf_lm):
+    metric = JailbreakAccuracy(is_jailbreak=always_jailbreak)
+
+    with pytest.raises(ValueError, match="empty batch"):
+        metric(mock_hf_lm, [], [])


### PR DESCRIPTION
This PR introduces a first draft of a BaseJailbreakAttack abstraction.
The goal is to define a minimal, prompt-wise interface for jailbreak attacks, aligned with the existing design used for evasion attacks.

The base class provides orchestration over a list of harmful behaviors and leaves attack-specific logic, success criteria, and objectives to specific attack implementations.