### PR TITLE
203 integrate additional attacks with wrappers from foolbox and advlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ SecML-Torch (SecMLT) is a PyTorch-native toolkit for evaluating and improving ad
 - **Modular design to build adaptive/custom attacks** to swap losses, optimizers, perturbation models, and add EoT easily with a few lines of code.
 - **Attack ensembling modules** to obtain worst-case per-sample robustness evaluations.
 - **Robustness evaluation tools** including metrics, logging, and trackers to ensure reproducibility and easy reporting.
-- **Attacl debugging support** such as built-in hooks and TensorBoard integration to monitor and inspect attack behavior.
+- **Attack debugging support** such as built-in hooks and TensorBoard integration to monitor and inspect attack behavior.
 
 Check out the [tutorials](https://secml-torch.readthedocs.io) to see SecML-Torch in action.
 
@@ -54,7 +54,17 @@ Check out the [tutorials](https://secml-torch.readthedocs.io) to see SecML-Torch
 | Test time | **PGD (fixed-epsilon, iterative attack)** | ✔ Native implementation | ✔ Also via backend wrappers (Foolbox, Adversarial Library). |
 | Test time | **FMN (minimum-norm, iterative attack)** | ✔ Native implementation | ✔ Also via backend wrappers (Foolbox, Adversarial Library). |
 | Test time | **DDN (minimum-norm, iterative attack)** | ✔ Native implementation | ✔ Also via backend wrappers (Foolbox, Adversarial Library). |
-| Test time | **Other Evasion Attacks** | Work in progress | ✔ Available via backend wrappers (Foolbox, Adversarial Library). |
+| Test time | **FGSM (Fast Gradient Sign Method)** | - | ✔ Available via backend wrappers (Foolbox, Adversarial Library). |
+| Test time | **CW (Carlini & Wagner L2)** | - | ✔ Available via backend wrappers (Foolbox, Adversarial Library). |
+| Test time | **DeepFool** | - | ✔ Available via backend wrappers (Foolbox, Adversarial Library). |
+| Test time | **VAT (Virtual Adversarial Training)** | - | ✔ Available via backend wrapper (Foolbox). |
+| Test time | **HopSkipJump (black-box attack)** | - | ✔ Available via backend wrapper (Foolbox). |
+| Test time | **Boundary Attack (black-box attack)** | - | ✔ Available via backend wrapper (Foolbox). |
+| Test time | **Spatial Attack** | - | ✔ Available via backend wrapper (Foolbox). |
+| Test time | **Additive Noise** | - | ✔ Available via backend wrapper (Foolbox). |
+| Test time | **Salt & Pepper Noise** | - | ✔ Available via backend wrapper (Foolbox). |
+| Test time | **Gaussian Blur** | - | ✔ Available via backend wrapper (Foolbox). |
+| Test time | **Contrast Reduction** | - | ✔ Available via backend wrapper (Foolbox). |
 | Training time | **Backdoor** | ✔ Native implementation | - |
 | Training time | **Label Flip Poisoning** | ✔ Native implementation | - |
 

--- a/docs/reference/secmlt.adv.evasion.advlib_attacks.rst
+++ b/docs/reference/secmlt.adv.evasion.advlib_attacks.rst
@@ -12,10 +12,34 @@ secmlt.adv.evasion.advlib\_attacks.advlib\_base module
    :undoc-members:
    :show-inheritance:
 
+secmlt.adv.evasion.advlib\_attacks.advlib\_cw module
+----------------------------------------------------
+
+.. automodule:: secmlt.adv.evasion.advlib_attacks.advlib_cw
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 secmlt.adv.evasion.advlib\_attacks.advlib\_ddn module
 -----------------------------------------------------
 
 .. automodule:: secmlt.adv.evasion.advlib_attacks.advlib_ddn
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+secmlt.adv.evasion.advlib\_attacks.advlib\_deepfool module
+----------------------------------------------------------
+
+.. automodule:: secmlt.adv.evasion.advlib_attacks.advlib_deepfool
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+secmlt.adv.evasion.advlib\_attacks.advlib\_fgsm module
+------------------------------------------------------
+
+.. automodule:: secmlt.adv.evasion.advlib_attacks.advlib_fgsm
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/reference/secmlt.adv.evasion.foolbox_attacks.rst
+++ b/docs/reference/secmlt.adv.evasion.foolbox_attacks.rst
@@ -4,10 +4,42 @@ secmlt.adv.evasion.foolbox\_attacks package
 Submodules
 ----------
 
+secmlt.adv.evasion.foolbox\_attacks.foolbox\_additive\_noise module
+-------------------------------------------------------------------
+
+.. automodule:: secmlt.adv.evasion.foolbox_attacks.foolbox_additive_noise
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 secmlt.adv.evasion.foolbox\_attacks.foolbox\_base module
 --------------------------------------------------------
 
 .. automodule:: secmlt.adv.evasion.foolbox_attacks.foolbox_base
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+secmlt.adv.evasion.foolbox\_attacks.foolbox\_boundary module
+------------------------------------------------------------
+
+.. automodule:: secmlt.adv.evasion.foolbox_attacks.foolbox_boundary
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+secmlt.adv.evasion.foolbox\_attacks.foolbox\_contrast\_reduction module
+-----------------------------------------------------------------------
+
+.. automodule:: secmlt.adv.evasion.foolbox_attacks.foolbox_contrast_reduction
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+secmlt.adv.evasion.foolbox\_attacks.foolbox\_cw module
+------------------------------------------------------
+
+.. automodule:: secmlt.adv.evasion.foolbox_attacks.foolbox_cw
    :members:
    :undoc-members:
    :show-inheritance:
@@ -20,6 +52,22 @@ secmlt.adv.evasion.foolbox\_attacks.foolbox\_ddn module
    :undoc-members:
    :show-inheritance:
 
+secmlt.adv.evasion.foolbox\_attacks.foolbox\_deepfool module
+------------------------------------------------------------
+
+.. automodule:: secmlt.adv.evasion.foolbox_attacks.foolbox_deepfool
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+secmlt.adv.evasion.foolbox\_attacks.foolbox\_fgsm module
+--------------------------------------------------------
+
+.. automodule:: secmlt.adv.evasion.foolbox_attacks.foolbox_fgsm
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 secmlt.adv.evasion.foolbox\_attacks.foolbox\_fmn module
 -------------------------------------------------------
 
@@ -28,10 +76,50 @@ secmlt.adv.evasion.foolbox\_attacks.foolbox\_fmn module
    :undoc-members:
    :show-inheritance:
 
+secmlt.adv.evasion.foolbox\_attacks.foolbox\_gaussian\_blur module
+------------------------------------------------------------------
+
+.. automodule:: secmlt.adv.evasion.foolbox_attacks.foolbox_gaussian_blur
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+secmlt.adv.evasion.foolbox\_attacks.foolbox\_hopskipjump module
+---------------------------------------------------------------
+
+.. automodule:: secmlt.adv.evasion.foolbox_attacks.foolbox_hopskipjump
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 secmlt.adv.evasion.foolbox\_attacks.foolbox\_pgd module
 -------------------------------------------------------
 
 .. automodule:: secmlt.adv.evasion.foolbox_attacks.foolbox_pgd
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+secmlt.adv.evasion.foolbox\_attacks.foolbox\_saltandpepper module
+-----------------------------------------------------------------
+
+.. automodule:: secmlt.adv.evasion.foolbox_attacks.foolbox_saltandpepper
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+secmlt.adv.evasion.foolbox\_attacks.foolbox\_spatial module
+-----------------------------------------------------------
+
+.. automodule:: secmlt.adv.evasion.foolbox_attacks.foolbox_spatial
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+secmlt.adv.evasion.foolbox\_attacks.foolbox\_vat module
+-------------------------------------------------------
+
+.. automodule:: secmlt.adv.evasion.foolbox_attacks.foolbox_vat
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/reference/secmlt.adv.evasion.rst
+++ b/docs/reference/secmlt.adv.evasion.rst
@@ -15,10 +15,42 @@ Subpackages
 Submodules
 ----------
 
+secmlt.adv.evasion.additive\_noise module
+-----------------------------------------
+
+.. automodule:: secmlt.adv.evasion.additive_noise
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 secmlt.adv.evasion.base\_evasion\_attack module
 -----------------------------------------------
 
 .. automodule:: secmlt.adv.evasion.base_evasion_attack
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+secmlt.adv.evasion.boundary\_attack module
+------------------------------------------
+
+.. automodule:: secmlt.adv.evasion.boundary_attack
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+secmlt.adv.evasion.contrast\_reduction module
+---------------------------------------------
+
+.. automodule:: secmlt.adv.evasion.contrast_reduction
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+secmlt.adv.evasion.cw module
+----------------------------
+
+.. automodule:: secmlt.adv.evasion.cw
    :members:
    :undoc-members:
    :show-inheritance:
@@ -31,10 +63,42 @@ secmlt.adv.evasion.ddn module
    :undoc-members:
    :show-inheritance:
 
+secmlt.adv.evasion.deepfool module
+----------------------------------
+
+.. automodule:: secmlt.adv.evasion.deepfool
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+secmlt.adv.evasion.fgsm module
+------------------------------
+
+.. automodule:: secmlt.adv.evasion.fgsm
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 secmlt.adv.evasion.fmn module
 -----------------------------
 
 .. automodule:: secmlt.adv.evasion.fmn
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+secmlt.adv.evasion.gaussian\_blur module
+----------------------------------------
+
+.. automodule:: secmlt.adv.evasion.gaussian_blur
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+secmlt.adv.evasion.hopskipjump module
+-------------------------------------
+
+.. automodule:: secmlt.adv.evasion.hopskipjump
    :members:
    :undoc-members:
    :show-inheritance:
@@ -51,6 +115,30 @@ secmlt.adv.evasion.pgd module
 -----------------------------
 
 .. automodule:: secmlt.adv.evasion.pgd
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+secmlt.adv.evasion.saltandpepper module
+---------------------------------------
+
+.. automodule:: secmlt.adv.evasion.saltandpepper
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+secmlt.adv.evasion.spatial\_attack module
+-----------------------------------------
+
+.. automodule:: secmlt.adv.evasion.spatial_attack
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+secmlt.adv.evasion.vat module
+-----------------------------
+
+.. automodule:: secmlt.adv.evasion.vat
    :members:
    :undoc-members:
    :show-inheritance:

--- a/src/secmlt/adv/evasion/additive_noise.py
+++ b/src/secmlt/adv/evasion/additive_noise.py
@@ -1,0 +1,96 @@
+"""Additive Noise attack implementation (Foolbox-only backend)."""
+
+from __future__ import annotations
+
+import importlib.util
+from typing import TYPE_CHECKING, Literal
+
+from secmlt.adv.backends import Backends
+from secmlt.adv.evasion.base_evasion_attack import (
+    BaseEvasionAttack,
+    BaseEvasionAttackCreator,
+)
+from secmlt.adv.evasion.perturbation_models import LpPerturbationModels
+
+if TYPE_CHECKING:
+    from secmlt.trackers.trackers import Tracker
+
+
+class AdditiveNoise(BaseEvasionAttackCreator):
+    """Creator for the Additive Noise attack."""
+
+    def __new__(
+        cls,
+        epsilon: float,
+        perturbation_model: str = LpPerturbationModels.L2,
+        noise_type: Literal["gaussian", "uniform"] = "gaussian",
+        y_target: int | None = None,
+        lb: float = 0.0,
+        ub: float = 1.0,
+        backend: str = Backends.FOOLBOX,
+        trackers: list[Tracker] | None = None,
+        **kwargs,
+    ) -> BaseEvasionAttack:
+        """
+        Create the Additive Noise attack.
+
+        The attack samples a random perturbation (Gaussian or uniform) and
+        scales it to the requested Lp norm.
+
+        Parameters
+        ----------
+        epsilon : float
+            Maximum size of the additive perturbation, measured with the norm
+            induced by ``perturbation_model``.
+        perturbation_model : str, optional
+            Norm constraint for the attack. Either L2 or Linf. Default is L2.
+        noise_type : str, optional
+            Distribution used to sample the noise. Either "gaussian" or
+            "uniform". Default is "gaussian". Note that "gaussian" is only
+            available for the L2 perturbation model.
+        y_target : int | None, optional
+            Target label for targeted attack. If None, the attack is
+            untargeted. Default is None.
+        lb : float, optional
+            Lower bound for the input domain. Default is 0.0.
+        ub : float, optional
+            Upper bound for the input domain. Default is 1.0.
+        backend : str, optional
+            Backend to use. Only Backends.FOOLBOX is supported.
+            Default is Backends.FOOLBOX.
+        trackers : list[Tracker] | None, optional
+            Trackers for monitoring attack metrics, by default None.
+
+        Returns
+        -------
+        BaseEvasionAttack
+            Additive Noise attack instance.
+        """
+        cls.check_backend_available(backend)
+        implementation = cls.get_implementation(backend)
+        return implementation(
+            epsilon=epsilon,
+            perturbation_model=perturbation_model,
+            noise_type=noise_type,
+            y_target=y_target,
+            lb=lb,
+            ub=ub,
+            trackers=trackers,
+            **kwargs,
+        )
+
+    @staticmethod
+    def get_backends() -> list[str]:
+        """Get available implementations for the Additive Noise attack."""
+        return [Backends.FOOLBOX]
+
+    @staticmethod
+    def _get_foolbox_implementation() -> type[AdditiveNoiseFoolbox]:  # noqa: F821
+        if importlib.util.find_spec("foolbox", None) is not None:
+            from secmlt.adv.evasion.foolbox_attacks.foolbox_additive_noise import (
+                AdditiveNoiseFoolbox,
+            )
+
+            return AdditiveNoiseFoolbox
+        msg = "foolbox extra not installed"
+        raise ImportError(msg)

--- a/src/secmlt/adv/evasion/advlib_attacks/__init__.py
+++ b/src/secmlt/adv/evasion/advlib_attacks/__init__.py
@@ -9,4 +9,4 @@ if importlib.util.find_spec("adv_lib", None) is not None:
     from .advlib_fgsm import *  # noqa: F403
     from .advlib_fmn import *  # noqa: F403
     from .advlib_pgd import *  # noqa: F403
-    
+

--- a/src/secmlt/adv/evasion/advlib_attacks/__init__.py
+++ b/src/secmlt/adv/evasion/advlib_attacks/__init__.py
@@ -1,11 +1,25 @@
 """Wrappers of Adversarial Library for evasion attacks."""
 
+import importlib.metadata
 import importlib.util
+
+
+def _adv_lib_gte(major: int, minor: int, patch: int) -> bool:
+    try:
+        version_str = importlib.metadata.version("adv-lib")
+    except importlib.metadata.PackageNotFoundError:
+        return False
+    else:
+        parts = tuple(int(x) for x in version_str.split(".")[:3])
+        return parts >= (major, minor, patch)
+
 
 if importlib.util.find_spec("adv_lib", None) is not None:
     from .advlib_cw import *  # noqa: F403
     from .advlib_ddn import *  # noqa: F403
-    from .advlib_deepfool import *  # noqa: F403
     from .advlib_fgsm import *  # noqa: F403
     from .advlib_fmn import *  # noqa: F403
     from .advlib_pgd import *  # noqa: F403
+
+    if _adv_lib_gte(0, 2, 3):
+        from .advlib_deepfool import *  # noqa: F403

--- a/src/secmlt/adv/evasion/advlib_attacks/__init__.py
+++ b/src/secmlt/adv/evasion/advlib_attacks/__init__.py
@@ -5,6 +5,7 @@ import importlib.util
 if importlib.util.find_spec("adv_lib", None) is not None:
     from .advlib_cw import *  # noqa: F403
     from .advlib_ddn import *  # noqa: F403
+    from .advlib_deepfool import *  # noqa: F403
     from .advlib_fgsm import *  # noqa: F403
     from .advlib_fmn import *  # noqa: F403
     from .advlib_pgd import *  # noqa: F403

--- a/src/secmlt/adv/evasion/advlib_attacks/__init__.py
+++ b/src/secmlt/adv/evasion/advlib_attacks/__init__.py
@@ -1,25 +1,12 @@
 """Wrappers of Adversarial Library for evasion attacks."""
 
-import importlib.metadata
 import importlib.util
-
-
-def _adv_lib_gte(major: int, minor: int, patch: int) -> bool:
-    try:
-        version_str = importlib.metadata.version("adv-lib")
-    except importlib.metadata.PackageNotFoundError:
-        return False
-    else:
-        parts = tuple(int(x) for x in version_str.split(".")[:3])
-        return parts >= (major, minor, patch)
-
 
 if importlib.util.find_spec("adv_lib", None) is not None:
     from .advlib_cw import *  # noqa: F403
     from .advlib_ddn import *  # noqa: F403
+    from .advlib_deepfool import *  # noqa: F403
     from .advlib_fgsm import *  # noqa: F403
     from .advlib_fmn import *  # noqa: F403
     from .advlib_pgd import *  # noqa: F403
-
-    if _adv_lib_gte(0, 2, 3):
-        from .advlib_deepfool import *  # noqa: F403
+    

--- a/src/secmlt/adv/evasion/advlib_attacks/__init__.py
+++ b/src/secmlt/adv/evasion/advlib_attacks/__init__.py
@@ -3,6 +3,7 @@
 import importlib.util
 
 if importlib.util.find_spec("adv_lib", None) is not None:
+    from .advlib_cw import *  # noqa: F403
     from .advlib_ddn import *  # noqa: F403
     from .advlib_fgsm import *  # noqa: F403
     from .advlib_fmn import *  # noqa: F403

--- a/src/secmlt/adv/evasion/advlib_attacks/__init__.py
+++ b/src/secmlt/adv/evasion/advlib_attacks/__init__.py
@@ -4,5 +4,6 @@ import importlib.util
 
 if importlib.util.find_spec("adv_lib", None) is not None:
     from .advlib_ddn import *  # noqa: F403
+    from .advlib_fgsm import *  # noqa: F403
     from .advlib_fmn import *  # noqa: F403
     from .advlib_pgd import *  # noqa: F403

--- a/src/secmlt/adv/evasion/advlib_attacks/advlib_cw.py
+++ b/src/secmlt/adv/evasion/advlib_attacks/advlib_cw.py
@@ -1,0 +1,73 @@
+"""Wrapper of the Carlini-Wagner attack implemented in Adversarial Library."""
+
+from __future__ import annotations  # noqa: I001
+
+from functools import partial
+
+from adv_lib.attacks.carlini_wagner import carlini_wagner_l2
+
+from secmlt.adv.evasion.advlib_attacks.advlib_base import BaseAdvLibEvasionAttack
+from secmlt.adv.evasion.perturbation_models import LpPerturbationModels
+
+
+class CWAdvLib(BaseAdvLibEvasionAttack):
+    """Wrapper of the Adversarial Library implementation of the CW L2 attack.
+
+    Parameters
+    ----------
+        binary_search_steps : int
+            Number of binary search steps for the const parameter. Default is 9.
+        num_steps : int
+            Number of optimization iterations per binary search step. Default is 10000.
+        step_size : float
+            Learning rate for the Adam optimizer. Default is 0.01.
+        confidence : float
+            Confidence margin for adversarial examples. Default is 0.0.
+        initial_const : float
+            Initial value of the regularization constant. Default is 0.001.
+        abort_early : bool
+            Abort binary search early if no improvement is found. Default is True.
+        y_target : int | None, optional
+            Target label for the attack. If None, the attack is untargeted.
+        lb : float, optional
+            Lower bound for the perturbation. Default is 0.0.
+        ub : float, optional
+            Upper bound for the perturbation. Default is 1.0.
+    """
+
+    def __init__(
+        self,
+        binary_search_steps: int = 9,
+        num_steps: int = 10000,
+        step_size: float = 0.01,
+        confidence: float = 0.0,
+        initial_const: float = 0.001,
+        abort_early: bool = True,
+        y_target: int | None = None,
+        lb: float = 0.0,
+        ub: float = 1.0,
+        **kwargs,
+    ) -> None:
+        """Initialize the Adversarial Library backend for the CW L2 attack."""
+        advlib_attack = partial(
+            carlini_wagner_l2,
+            binary_search_steps=binary_search_steps,
+            max_iterations=num_steps,
+            learning_rate=step_size,
+            confidence=confidence,
+            initial_const=initial_const,
+            abort_early=abort_early,
+        )
+
+        super().__init__(
+            advlib_attack=advlib_attack,
+            y_target=y_target,
+            lb=lb,
+            ub=ub,
+            **kwargs,
+        )
+
+    @staticmethod
+    def get_perturbation_models() -> set[str]:
+        """Return the perturbation models available for this attack."""
+        return {LpPerturbationModels.L2}

--- a/src/secmlt/adv/evasion/advlib_attacks/advlib_deepfool.py
+++ b/src/secmlt/adv/evasion/advlib_attacks/advlib_deepfool.py
@@ -1,0 +1,56 @@
+"""Wrapper of the DeepFool attack implemented in Adversarial Library."""
+
+from __future__ import annotations
+
+from functools import partial
+
+from adv_lib.attacks.deepfool import df
+
+from secmlt.adv.evasion.advlib_attacks.advlib_base import BaseAdvLibEvasionAttack
+from secmlt.adv.evasion.perturbation_models import LpPerturbationModels
+
+
+class DeepFoolAdvLib(BaseAdvLibEvasionAttack):
+    """Wrapper of the Adversarial Library implementation of the DeepFool L2 attack.
+
+    Parameters
+    ----------
+        num_steps : int
+            Maximum number of steps to perform. Default is 100.
+        overshoot : float, optional
+            Ratio by which to overshoot the decision boundary. Default is 0.02.
+        lb : float, optional
+            Lower bound for the perturbation. Default is 0.0.
+        ub : float, optional
+            Upper bound for the perturbation. Default is 1.0.
+    """
+
+    def __init__(
+        self,
+        num_steps: int = 100,
+        overshoot: float = 0.02,
+        lb: float = 0.0,
+        ub: float = 1.0,
+        **kwargs,
+    ) -> None:
+        """Initialize the Adversarial Library backend for the DeepFool L2 attack."""
+        kwargs.pop("candidates", None)  # foolbox-only parameter
+        advlib_attack = partial(
+            df,
+            steps=num_steps,
+            overshoot=overshoot,
+            norm=2,
+        )
+
+        super().__init__(
+            advlib_attack=advlib_attack,
+            y_target=None,
+            lb=lb,
+            ub=ub,
+            **kwargs,
+        )
+
+    @staticmethod
+    def get_perturbation_models() -> set[str]:
+        """Return the perturbation models available for this attack."""
+        return {LpPerturbationModels.L2}

--- a/src/secmlt/adv/evasion/advlib_attacks/advlib_deepfool.py
+++ b/src/secmlt/adv/evasion/advlib_attacks/advlib_deepfool.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from functools import partial
 
 from adv_lib.attacks.deepfool import df
-
 from secmlt.adv.evasion.advlib_attacks.advlib_base import BaseAdvLibEvasionAttack
 from secmlt.adv.evasion.perturbation_models import LpPerturbationModels
 

--- a/src/secmlt/adv/evasion/advlib_attacks/advlib_fgsm.py
+++ b/src/secmlt/adv/evasion/advlib_attacks/advlib_fgsm.py
@@ -1,0 +1,92 @@
+"""Wrapper of the FGSM attack implemented in Adversarial Library."""
+
+from __future__ import annotations
+
+from functools import partial
+
+from adv_lib.attacks import pgd_linf
+from secmlt.adv.evasion.advlib_attacks.advlib_base import BaseAdvLibEvasionAttack
+from secmlt.adv.evasion.perturbation_models import LpPerturbationModels
+
+
+class FGSMAdvLib(BaseAdvLibEvasionAttack):
+    """Wrapper of the Adversarial Library implementation of the FGSM attack."""
+
+    def __init__(
+        self,
+        perturbation_model: str,
+        epsilon: float,
+        loss_function: str = "ce",
+        y_target: int | None = None,
+        lb: float = 0.0,
+        ub: float = 1.0,
+        **kwargs,
+    ) -> None:
+        """
+        Initialize an FGSM attack with the Adversarial Library backend.
+
+        Parameters
+        ----------
+        perturbation_model : str
+            The perturbation model to be used for the attack.
+        epsilon : float
+            The maximum perturbation allowed.
+        loss_function : str, optional
+            The loss function to be used for the attack. The default value is "ce".
+        y_target : int | None, optional
+            The target label for the attack. If None, the attack is
+            untargeted. The default value is None.
+        lb : float, optional
+            The lower bound for the perturbation. The default value is 0.0.
+        ub : float, optional
+            The upper bound for the perturbation. The default value is 1.0.
+
+        Raises
+        ------
+        ValueError
+            If the provided `loss_function` is not supported by the FGSM attack
+            using the Adversarial Library backend.
+        """
+        perturbation_models = {
+            LpPerturbationModels.LINF: pgd_linf,
+        }
+        losses: list[str] = ["ce", "dl", "dlr"]
+        if isinstance(loss_function, str):
+            if loss_function not in losses:
+                msg = f"FGSM AdvLib supports only these losses: {losses}"
+                raise ValueError(msg)
+        else:
+            loss_function = losses[0]
+
+        advlib_attack_func = perturbation_models.get(perturbation_model)
+        advlib_attack = partial(
+            advlib_attack_func,
+            steps=1,
+            random_init=False,
+            restarts=1,
+            loss_function=loss_function,
+            absolute_step_size=epsilon,
+        )
+
+        super().__init__(
+            advlib_attack=advlib_attack,
+            epsilon=epsilon,
+            y_target=y_target,
+            lb=lb,
+            ub=ub,
+            **kwargs,
+        )
+
+    @staticmethod
+    def get_perturbation_models() -> set[str]:
+        """
+        Check the perturbation models implemented for this attack.
+
+        Returns
+        -------
+        set[str]
+            The list of perturbation models implemented for this attack.
+        """
+        return {
+            LpPerturbationModels.LINF,
+        }

--- a/src/secmlt/adv/evasion/boundary_attack.py
+++ b/src/secmlt/adv/evasion/boundary_attack.py
@@ -1,0 +1,110 @@
+"""Boundary Attack implementation (Foolbox-only backend)."""
+
+from __future__ import annotations
+
+import importlib.util
+from typing import TYPE_CHECKING
+
+from secmlt.adv.backends import Backends
+from secmlt.adv.evasion.base_evasion_attack import (
+    BaseEvasionAttack,
+    BaseEvasionAttackCreator,
+)
+
+if TYPE_CHECKING:
+    from secmlt.trackers.trackers import Tracker
+
+
+class BoundaryAttack(BaseEvasionAttackCreator):
+    """Creator for the decision-based Boundary Attack."""
+
+    def __new__(
+        cls,
+        steps: int = 25000,
+        spherical_step: float = 0.01,
+        source_step: float = 0.01,
+        source_step_convergance: float = 1e-7,
+        step_adaptation: float = 1.5,
+        update_stats_every_k: int = 10,
+        y_target: int | None = None,
+        lb: float = 0.0,
+        ub: float = 1.0,
+        backend: str = Backends.FOOLBOX,
+        trackers: list[Tracker] | None = None,
+        **kwargs,
+    ) -> BaseEvasionAttack:
+        """
+        Create the Boundary Attack.
+
+        References
+        ----------
+        .. [#Bren17] Wieland Brendel, Jonas Rauber, Matthias Bethge,
+            "Decision-Based Adversarial Attacks: Reliable Attacks Against
+            Black-Box Machine Learning Models",
+            https://arxiv.org/abs/1712.04248
+
+        Parameters
+        ----------
+        steps : int, optional
+            Number of steps to run. Default is 25000.
+        spherical_step : float, optional
+            Initial step size for the orthogonal (spherical) step.
+            Default is 0.01.
+        source_step : float, optional
+            Initial step size for the step toward the target. Default is 0.01.
+        source_step_convergance : float, optional
+            Convergence threshold for the source step. Default is 1e-7.
+        step_adaptation : float, optional
+            Factor to adapt the step sizes. Default is 1.5.
+        update_stats_every_k : int, optional
+            How often to update statistics used for step adaptation.
+            Default is 10.
+        y_target : int | None, optional
+            Target label for targeted attack. If None, the attack is
+            untargeted. Default is None.
+        lb : float, optional
+            Lower bound for the input domain. Default is 0.0.
+        ub : float, optional
+            Upper bound for the input domain. Default is 1.0.
+        backend : str, optional
+            Backend to use. Only Backends.FOOLBOX is supported.
+            Default is Backends.FOOLBOX.
+        trackers : list[Tracker] | None, optional
+            Trackers for monitoring attack metrics, by default None.
+
+        Returns
+        -------
+        BaseEvasionAttack
+            Boundary Attack instance.
+        """
+        cls.check_backend_available(backend)
+        implementation = cls.get_implementation(backend)
+        return implementation(
+            steps=steps,
+            spherical_step=spherical_step,
+            source_step=source_step,
+            source_step_convergance=source_step_convergance,
+            step_adaptation=step_adaptation,
+            update_stats_every_k=update_stats_every_k,
+            y_target=y_target,
+            lb=lb,
+            ub=ub,
+            trackers=trackers,
+            **kwargs,
+        )
+
+    @staticmethod
+    def get_backends() -> list[str]:
+        """Get available implementations for the Boundary Attack."""
+        return [Backends.FOOLBOX]
+
+    @staticmethod
+    def _get_foolbox_implementation() -> type[BoundaryAttackFoolbox]:  # noqa: F821
+        if importlib.util.find_spec("foolbox", None) is not None:
+            from secmlt.adv.evasion.foolbox_attacks.foolbox_boundary import (
+                BoundaryAttackFoolbox,
+            )
+
+            return BoundaryAttackFoolbox
+        msg = "foolbox extra not installed"
+        raise ImportError(msg)

--- a/src/secmlt/adv/evasion/contrast_reduction.py
+++ b/src/secmlt/adv/evasion/contrast_reduction.py
@@ -1,0 +1,89 @@
+"""Contrast Reduction attack implementation (Foolbox-only backend)."""
+
+from __future__ import annotations
+
+import importlib.util
+from typing import TYPE_CHECKING
+
+from secmlt.adv.backends import Backends
+from secmlt.adv.evasion.base_evasion_attack import (
+    BaseEvasionAttack,
+    BaseEvasionAttackCreator,
+)
+
+if TYPE_CHECKING:
+    from secmlt.trackers.trackers import Tracker
+
+
+class ContrastReduction(BaseEvasionAttackCreator):
+    """Creator for the Contrast Reduction attack."""
+
+    def __new__(
+        cls,
+        epsilon: float,
+        target: float = 0.5,
+        y_target: int | None = None,
+        lb: float = 0.0,
+        ub: float = 1.0,
+        backend: str = Backends.FOOLBOX,
+        trackers: list[Tracker] | None = None,
+        **kwargs,
+    ) -> BaseEvasionAttack:
+        """
+        Create the Contrast Reduction attack.
+
+        Reduces the contrast of the input, moving every pixel towards the
+        ``target`` value, using an additive perturbation of the given L2 size.
+
+        Parameters
+        ----------
+        epsilon : float
+            Maximum L2 size of the contrast-reducing perturbation.
+        target : float, optional
+            Value towards which the pixels are moved when reducing the
+            contrast. Default is 0.5.
+        y_target : int | None, optional
+            Target label for targeted attack. If None, the attack is
+            untargeted. Default is None.
+        lb : float, optional
+            Lower bound for the input domain. Default is 0.0.
+        ub : float, optional
+            Upper bound for the input domain. Default is 1.0.
+        backend : str, optional
+            Backend to use. Only Backends.FOOLBOX is supported.
+            Default is Backends.FOOLBOX.
+        trackers : list[Tracker] | None, optional
+            Trackers for monitoring attack metrics, by default None.
+
+        Returns
+        -------
+        BaseEvasionAttack
+            Contrast Reduction attack instance.
+        """
+        cls.check_backend_available(backend)
+        implementation = cls.get_implementation(backend)
+        return implementation(
+            epsilon=epsilon,
+            target=target,
+            y_target=y_target,
+            lb=lb,
+            ub=ub,
+            trackers=trackers,
+            **kwargs,
+        )
+
+    @staticmethod
+    def get_backends() -> list[str]:
+        """Get available implementations for the Contrast Reduction attack."""
+        return [Backends.FOOLBOX]
+
+    @staticmethod
+    def _get_foolbox_implementation() -> type[ContrastReductionFoolbox]:  # noqa: F821
+        if importlib.util.find_spec("foolbox", None) is not None:
+            from secmlt.adv.evasion.foolbox_attacks.foolbox_contrast_reduction import (
+                ContrastReductionFoolbox,
+            )
+
+            return ContrastReductionFoolbox
+        msg = "foolbox extra not installed"
+        raise ImportError(msg)

--- a/src/secmlt/adv/evasion/cw.py
+++ b/src/secmlt/adv/evasion/cw.py
@@ -1,0 +1,117 @@
+"""Carlini and Wagner (CW) L2 attack implementation."""
+
+from __future__ import annotations  # noqa: I001
+
+import importlib.util
+
+from secmlt.adv.backends import Backends
+from secmlt.adv.evasion.base_evasion_attack import (
+    BaseEvasionAttack,
+    BaseEvasionAttackCreator,
+)
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from secmlt.trackers.trackers import Tracker
+
+
+class CW(BaseEvasionAttackCreator):
+    """Creator for the Carlini and Wagner (CW) L2 attack."""
+
+    def __new__(
+        cls,
+        binary_search_steps: int = 9,
+        num_steps: int = 10000,
+        step_size: float = 0.01,
+        confidence: float = 0.0,
+        initial_const: float = 0.001,
+        abort_early: bool = True,
+        y_target: int | None = None,
+        lb: float = 0.0,
+        ub: float = 1.0,
+        backend: str = Backends.FOOLBOX,
+        trackers: list[Tracker] | None = None,
+        **kwargs,
+    ) -> BaseEvasionAttack:
+        """
+        Create the CW L2 attack.
+
+        References
+        ----------
+        .. [#CW17] Nicholas Carlini and David Wagner, "Towards Evaluating the
+            Robustness of Neural Networks", IEEE S&P 2017,
+            https://arxiv.org/abs/1608.04644
+
+        Parameters
+        ----------
+        binary_search_steps : int, optional
+            Number of binary search steps for the regularization constant.
+            Default is 9.
+        num_steps : int, optional
+            Number of optimization iterations per binary search step.
+            Default is 10000.
+        step_size : float, optional
+            Learning rate for the Adam optimizer. Default is 0.01.
+        confidence : float, optional
+            Confidence margin kappa for the adversarial objective. Default is 0.0.
+        initial_const : float, optional
+            Initial value of the regularization constant c. Default is 0.001.
+        abort_early : bool, optional
+            Abort binary search early when no improvement is observed.
+            Default is True.
+        y_target : int | None, optional
+            Target label for the attack. If None, the attack is untargeted.
+            Default is None.
+        lb : float, optional
+            Lower bound for the input domain. Default is 0.0.
+        ub : float, optional
+            Upper bound for the input domain. Default is 1.0.
+        backend : str, optional
+            Backend to use to run the attack. Default is Backends.FOOLBOX.
+        trackers : list[Tracker] | None, optional
+            Trackers to check various attack metrics (see secmlt.trackers),
+            by default None.
+
+        Returns
+        -------
+        BaseEvasionAttack
+            CW L2 attack instance.
+        """
+        cls.check_backend_available(backend)
+        implementation = cls.get_implementation(backend)
+        return implementation(
+            binary_search_steps=binary_search_steps,
+            num_steps=num_steps,
+            step_size=step_size,
+            confidence=confidence,
+            initial_const=initial_const,
+            abort_early=abort_early,
+            y_target=y_target,
+            lb=lb,
+            ub=ub,
+            trackers=trackers,
+            **kwargs,
+        )
+
+    @staticmethod
+    def get_backends() -> list[str]:
+        """Get available implementations for the CW attack."""
+        return [Backends.FOOLBOX, Backends.ADVLIB]
+
+    @staticmethod
+    def _get_foolbox_implementation() -> type[CWFoolbox]:  # noqa: F821
+        if importlib.util.find_spec("foolbox", None) is not None:
+            from secmlt.adv.evasion.foolbox_attacks.foolbox_cw import CWFoolbox
+
+            return CWFoolbox
+        msg = "foolbox extra not installed"
+        raise ImportError(msg)
+
+    @staticmethod
+    def _get_advlib_implementation() -> type[CWAdvLib]:  # noqa: F821
+        if importlib.util.find_spec("adv_lib", None) is not None:
+            from secmlt.adv.evasion.advlib_attacks.advlib_cw import CWAdvLib
+
+            return CWAdvLib
+        msg = "adv_lib extra not installed"
+        raise ImportError(msg)

--- a/src/secmlt/adv/evasion/deepfool.py
+++ b/src/secmlt/adv/evasion/deepfool.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import importlib.util
+from typing import TYPE_CHECKING
 
 from secmlt.adv.backends import Backends
 from secmlt.adv.evasion.base_evasion_attack import (
     BaseEvasionAttack,
     BaseEvasionAttackCreator,
 )
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from secmlt.trackers.trackers import Tracker

--- a/src/secmlt/adv/evasion/deepfool.py
+++ b/src/secmlt/adv/evasion/deepfool.py
@@ -1,0 +1,101 @@
+"""DeepFool L2 attack implementation."""
+
+from __future__ import annotations
+
+import importlib.util
+
+from secmlt.adv.backends import Backends
+from secmlt.adv.evasion.base_evasion_attack import (
+    BaseEvasionAttack,
+    BaseEvasionAttackCreator,
+)
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from secmlt.trackers.trackers import Tracker
+
+
+class DeepFool(BaseEvasionAttackCreator):
+    """Creator for the DeepFool L2 attack."""
+
+    def __new__(
+        cls,
+        num_steps: int = 50,
+        overshoot: float = 0.02,
+        candidates: int | None = 10,
+        lb: float = 0.0,
+        ub: float = 1.0,
+        backend: str = Backends.FOOLBOX,
+        trackers: list[Tracker] | None = None,
+        **kwargs,
+    ) -> BaseEvasionAttack:
+        """
+        Create the DeepFool L2 attack.
+
+        References
+        ----------
+        .. [#Moos15] Seyed-Mohsen Moosavi-Dezfooli, Alhussein Fawzi, Pascal Frossard,
+            "DeepFool: a simple and accurate method to fool deep neural
+            networks", https://arxiv.org/abs/1511.04599
+
+        Parameters
+        ----------
+        num_steps : int, optional
+            Maximum number of steps to perform. Default is 50.
+        overshoot : float, optional
+            How much to overshoot the decision boundary. Default is 0.02.
+        candidates : int | None, optional
+            Limit on the number of the most likely classes to consider
+            (Foolbox backend only). Default is 10.
+        lb : float, optional
+            Lower bound for the input domain. Default is 0.0.
+        ub : float, optional
+            Upper bound for the input domain. Default is 1.0.
+        backend : str, optional
+            Backend to use to run the attack. Default is Backends.FOOLBOX.
+        trackers : list[Tracker] | None, optional
+            Trackers for monitoring attack metrics, by default None.
+
+        Returns
+        -------
+        BaseEvasionAttack
+            DeepFool L2 attack instance.
+        """
+        cls.check_backend_available(backend)
+        implementation = cls.get_implementation(backend)
+        return implementation(
+            num_steps=num_steps,
+            overshoot=overshoot,
+            candidates=candidates,
+            lb=lb,
+            ub=ub,
+            trackers=trackers,
+            **kwargs,
+        )
+
+    @staticmethod
+    def get_backends() -> list[str]:
+        """Get available implementations for the DeepFool attack."""
+        return [Backends.FOOLBOX, Backends.ADVLIB]
+
+    @staticmethod
+    def _get_foolbox_implementation() -> type[DeepFoolFoolbox]:  # noqa: F821
+        if importlib.util.find_spec("foolbox", None) is not None:
+            from secmlt.adv.evasion.foolbox_attacks.foolbox_deepfool import (
+                DeepFoolFoolbox,
+            )
+
+            return DeepFoolFoolbox
+        msg = "foolbox extra not installed"
+        raise ImportError(msg)
+
+    @staticmethod
+    def _get_advlib_implementation() -> type[DeepFoolAdvLib]:  # noqa: F821
+        if importlib.util.find_spec("adv_lib", None) is not None:
+            from secmlt.adv.evasion.advlib_attacks.advlib_deepfool import (
+                DeepFoolAdvLib,
+            )
+
+            return DeepFoolAdvLib
+        msg = "adv_lib extra not installed"
+        raise ImportError(msg)

--- a/src/secmlt/adv/evasion/fgsm.py
+++ b/src/secmlt/adv/evasion/fgsm.py
@@ -1,0 +1,107 @@
+"""Implementation of the Fast Gradient Sign Method (FGSM) evasion attack."""
+
+from __future__ import annotations  # noqa: I001
+
+import importlib.util
+
+from secmlt.adv.backends import Backends
+from secmlt.adv.evasion.base_evasion_attack import (
+    BaseEvasionAttack,
+    BaseEvasionAttackCreator,
+)
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from secmlt.trackers.trackers import Tracker
+
+
+class FGSM(BaseEvasionAttackCreator):
+    """Creator for the Fast Gradient Sign Method (FGSM) attack."""
+
+    def __new__(
+        cls,
+        perturbation_model: str,
+        epsilon: float,
+        loss_function: str = "ce",
+        y_target: int | None = None,
+        lb: float = 0.0,
+        ub: float = 1.0,
+        backend: str = Backends.FOOLBOX,
+        trackers: list[Tracker] | None = None,
+        **kwargs,
+    ) -> BaseEvasionAttack:
+        """
+        Create the FGSM attack.
+
+        Parameters
+        ----------
+        perturbation_model : str
+            Perturbation model for the attack.
+        epsilon : float
+            Maximum perturbation allowed.
+        loss_function : str, optional
+            Loss function to use (advlib backend only), by default "ce".
+        y_target : int | None, optional
+            Target label for a targeted attack, None for untargeted,
+            by default None.
+        lb : float, optional
+            Lower bound of the input space, by default 0.0.
+        ub : float, optional
+            Upper bound of the input space, by default 1.0.
+        backend : str, optional
+            Backend to use to run the attack, by default Backends.FOOLBOX.
+        trackers : list[Tracker] | None, optional
+            Trackers to check various attack metrics (see secmlt.trackers),
+            available only for native implementation, by default None.
+
+        Returns
+        -------
+        BaseEvasionAttack
+            FGSM attack instance.
+        """
+        cls.check_backend_available(backend)
+        implementation = cls.get_implementation(backend)
+        implementation.check_perturbation_model_available(perturbation_model)
+        if backend == Backends.ADVLIB:
+            return implementation(
+                perturbation_model=perturbation_model,
+                epsilon=epsilon,
+                loss_function=loss_function,
+                y_target=y_target,
+                lb=lb,
+                ub=ub,
+                trackers=trackers,
+                **kwargs,
+            )
+        return implementation(
+            perturbation_model=perturbation_model,
+            epsilon=epsilon,
+            y_target=y_target,
+            lb=lb,
+            ub=ub,
+            trackers=trackers,
+            **kwargs,
+        )
+
+    @staticmethod
+    def get_backends() -> list[str]:
+        """Get available implementations for the FGSM attack."""
+        return [Backends.FOOLBOX, Backends.ADVLIB]
+
+    @staticmethod
+    def _get_foolbox_implementation() -> type[FGSMFoolbox]:  # noqa: F821
+        if importlib.util.find_spec("foolbox", None) is not None:
+            from secmlt.adv.evasion.foolbox_attacks.foolbox_fgsm import FGSMFoolbox
+
+            return FGSMFoolbox
+        msg = "foolbox extra not installed"
+        raise ImportError(msg)
+
+    @staticmethod
+    def _get_advlib_implementation() -> type[FGSMAdvLib]:  # noqa: F821
+        if importlib.util.find_spec("adv_lib", None) is not None:
+            from secmlt.adv.evasion.advlib_attacks.advlib_fgsm import FGSMAdvLib
+
+            return FGSMAdvLib
+        msg = "adv_lib extra not installed"
+        raise ImportError(msg)

--- a/src/secmlt/adv/evasion/foolbox_attacks/__init__.py
+++ b/src/secmlt/adv/evasion/foolbox_attacks/__init__.py
@@ -10,4 +10,5 @@ if importlib.util.find_spec("foolbox", None) is not None:
     from .foolbox_fgsm import *  # noqa: F403
     from .foolbox_hopskipjump import *  # noqa: F403
     from .foolbox_pgd import *  # noqa: F403
+    from .foolbox_spatial import *  # noqa: F403
     from .foolbox_vat import *  # noqa: F403

--- a/src/secmlt/adv/evasion/foolbox_attacks/__init__.py
+++ b/src/secmlt/adv/evasion/foolbox_attacks/__init__.py
@@ -3,6 +3,7 @@
 import importlib.util
 
 if importlib.util.find_spec("foolbox", None) is not None:
+    from .foolbox_cw import *  # noqa: F403
     from .foolbox_ddn import *  # noqa: F403
     from .foolbox_fgsm import *  # noqa: F403
     from .foolbox_pgd import *  # noqa: F403

--- a/src/secmlt/adv/evasion/foolbox_attacks/__init__.py
+++ b/src/secmlt/adv/evasion/foolbox_attacks/__init__.py
@@ -11,5 +11,6 @@ if importlib.util.find_spec("foolbox", None) is not None:
     from .foolbox_fgsm import *  # noqa: F403
     from .foolbox_hopskipjump import *  # noqa: F403
     from .foolbox_pgd import *  # noqa: F403
+    from .foolbox_saltandpepper import *  # noqa: F403
     from .foolbox_spatial import *  # noqa: F403
     from .foolbox_vat import *  # noqa: F403

--- a/src/secmlt/adv/evasion/foolbox_attacks/__init__.py
+++ b/src/secmlt/adv/evasion/foolbox_attacks/__init__.py
@@ -8,5 +8,6 @@ if importlib.util.find_spec("foolbox", None) is not None:
     from .foolbox_ddn import *  # noqa: F403
     from .foolbox_deepfool import *  # noqa: F403
     from .foolbox_fgsm import *  # noqa: F403
+    from .foolbox_hopskipjump import *  # noqa: F403
     from .foolbox_pgd import *  # noqa: F403
     from .foolbox_vat import *  # noqa: F403

--- a/src/secmlt/adv/evasion/foolbox_attacks/__init__.py
+++ b/src/secmlt/adv/evasion/foolbox_attacks/__init__.py
@@ -4,4 +4,5 @@ import importlib.util
 
 if importlib.util.find_spec("foolbox", None) is not None:
     from .foolbox_ddn import *  # noqa: F403
+    from .foolbox_fgsm import *  # noqa: F403
     from .foolbox_pgd import *  # noqa: F403

--- a/src/secmlt/adv/evasion/foolbox_attacks/__init__.py
+++ b/src/secmlt/adv/evasion/foolbox_attacks/__init__.py
@@ -8,3 +8,4 @@ if importlib.util.find_spec("foolbox", None) is not None:
     from .foolbox_deepfool import *  # noqa: F403
     from .foolbox_fgsm import *  # noqa: F403
     from .foolbox_pgd import *  # noqa: F403
+    from .foolbox_vat import *  # noqa: F403

--- a/src/secmlt/adv/evasion/foolbox_attacks/__init__.py
+++ b/src/secmlt/adv/evasion/foolbox_attacks/__init__.py
@@ -5,5 +5,6 @@ import importlib.util
 if importlib.util.find_spec("foolbox", None) is not None:
     from .foolbox_cw import *  # noqa: F403
     from .foolbox_ddn import *  # noqa: F403
+    from .foolbox_deepfool import *  # noqa: F403
     from .foolbox_fgsm import *  # noqa: F403
     from .foolbox_pgd import *  # noqa: F403

--- a/src/secmlt/adv/evasion/foolbox_attacks/__init__.py
+++ b/src/secmlt/adv/evasion/foolbox_attacks/__init__.py
@@ -3,6 +3,7 @@
 import importlib.util
 
 if importlib.util.find_spec("foolbox", None) is not None:
+    from .foolbox_boundary import *  # noqa: F403
     from .foolbox_cw import *  # noqa: F403
     from .foolbox_ddn import *  # noqa: F403
     from .foolbox_deepfool import *  # noqa: F403

--- a/src/secmlt/adv/evasion/foolbox_attacks/__init__.py
+++ b/src/secmlt/adv/evasion/foolbox_attacks/__init__.py
@@ -3,6 +3,7 @@
 import importlib.util
 
 if importlib.util.find_spec("foolbox", None) is not None:
+    from .foolbox_additive_noise import *  # noqa: F403
     from .foolbox_boundary import *  # noqa: F403
     from .foolbox_cw import *  # noqa: F403
     from .foolbox_ddn import *  # noqa: F403

--- a/src/secmlt/adv/evasion/foolbox_attacks/__init__.py
+++ b/src/secmlt/adv/evasion/foolbox_attacks/__init__.py
@@ -5,10 +5,12 @@ import importlib.util
 if importlib.util.find_spec("foolbox", None) is not None:
     from .foolbox_additive_noise import *  # noqa: F403
     from .foolbox_boundary import *  # noqa: F403
+    from .foolbox_contrast_reduction import *  # noqa: F403
     from .foolbox_cw import *  # noqa: F403
     from .foolbox_ddn import *  # noqa: F403
     from .foolbox_deepfool import *  # noqa: F403
     from .foolbox_fgsm import *  # noqa: F403
+    from .foolbox_gaussian_blur import *  # noqa: F403
     from .foolbox_hopskipjump import *  # noqa: F403
     from .foolbox_pgd import *  # noqa: F403
     from .foolbox_saltandpepper import *  # noqa: F403

--- a/src/secmlt/adv/evasion/foolbox_attacks/foolbox_additive_noise.py
+++ b/src/secmlt/adv/evasion/foolbox_attacks/foolbox_additive_noise.py
@@ -1,0 +1,86 @@
+"""Wrapper of the Additive Noise attacks implemented in Foolbox."""
+
+from __future__ import annotations
+
+from typing import ClassVar, Literal
+
+from foolbox.attacks.additive_noise import (
+    L2AdditiveGaussianNoiseAttack,
+    L2AdditiveUniformNoiseAttack,
+    LinfAdditiveUniformNoiseAttack,
+)
+from secmlt.adv.evasion.foolbox_attacks.foolbox_base import BaseFoolboxEvasionAttack
+from secmlt.adv.evasion.perturbation_models import LpPerturbationModels
+
+
+class AdditiveNoiseFoolbox(BaseFoolboxEvasionAttack):
+    """Wrapper of the Foolbox implementation of the Additive Noise attacks.
+
+    The attack samples a random perturbation (Gaussian or uniform) and scales
+    it to the requested Lp norm. The supported combinations of perturbation
+    model and noise type are:
+
+    * ``L2`` with ``"gaussian"`` (default)
+    * ``L2`` with ``"uniform"``
+    * ``Linf`` with ``"uniform"``
+
+    Parameters
+    ----------
+    epsilon : float
+        Maximum size of the additive perturbation, measured with the norm
+        induced by ``perturbation_model``.
+    perturbation_model : str, optional
+        Norm constraint for the attack. Either L2 or Linf. Default is L2.
+    noise_type : str, optional
+        Distribution used to sample the noise. Either "gaussian" or "uniform".
+        Default is "gaussian". Note that "gaussian" is only available for the
+        L2 perturbation model.
+    y_target : int | None, optional
+        Target label for targeted attack. If None, the attack is untargeted.
+        Default is None.
+    lb : float, optional
+        Lower bound for the input domain. Default is 0.0.
+    ub : float, optional
+        Upper bound for the input domain. Default is 1.0.
+    """
+
+    _ATTACK_MAP: ClassVar[dict[tuple[str, str], type]] = {
+        (LpPerturbationModels.L2, "gaussian"): L2AdditiveGaussianNoiseAttack,
+        (LpPerturbationModels.L2, "uniform"): L2AdditiveUniformNoiseAttack,
+        (LpPerturbationModels.LINF, "uniform"): LinfAdditiveUniformNoiseAttack,
+    }
+
+    def __init__(
+        self,
+        epsilon: float,
+        perturbation_model: str = LpPerturbationModels.L2,
+        noise_type: Literal["gaussian", "uniform"] = "gaussian",
+        y_target: int | None = None,
+        lb: float = 0.0,
+        ub: float = 1.0,
+        **kwargs,
+    ) -> None:
+        """Create Additive Noise attack with Foolbox backend."""
+        foolbox_attack_cls = self._ATTACK_MAP.get((perturbation_model, noise_type))
+        if foolbox_attack_cls is None:
+            msg = (
+                f"Unsupported combination of perturbation model "
+                f"'{perturbation_model}' and noise type '{noise_type}' for the "
+                f"Additive Noise attack."
+            )
+            raise NotImplementedError(msg)
+        foolbox_attack = foolbox_attack_cls()
+
+        super().__init__(
+            foolbox_attack=foolbox_attack,
+            epsilon=epsilon,
+            y_target=y_target,
+            lb=lb,
+            ub=ub,
+            **kwargs,
+        )
+
+    @staticmethod
+    def get_perturbation_models() -> set[str]:
+        """Check the perturbation models implemented for this attack."""
+        return {LpPerturbationModels.L2, LpPerturbationModels.LINF}

--- a/src/secmlt/adv/evasion/foolbox_attacks/foolbox_boundary.py
+++ b/src/secmlt/adv/evasion/foolbox_attacks/foolbox_boundary.py
@@ -1,0 +1,81 @@
+"""Wrapper of the Boundary Attack implemented in Foolbox."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from foolbox.attacks.boundary_attack import BoundaryAttack
+from secmlt.adv.evasion.foolbox_attacks.foolbox_base import BaseFoolboxEvasionAttack
+from secmlt.adv.evasion.perturbation_models import LpPerturbationModels
+
+if TYPE_CHECKING:
+    from foolbox.attacks.base import MinimizationAttack
+
+
+class BoundaryAttackFoolbox(BaseFoolboxEvasionAttack):
+    """Wrapper of the Foolbox implementation of the Boundary Attack.
+
+    Parameters
+    ----------
+    init_attack : MinimizationAttack | None, optional
+        Attack used to find an initial adversarial example. If None, Foolbox
+        falls back to LinearSearchBlendedUniformNoiseAttack. Default is None.
+    steps : int, optional
+        Number of steps to run. Default is 25000.
+    spherical_step : float, optional
+        Initial step size for the orthogonal (spherical) step. Default is 0.01.
+    source_step : float, optional
+        Initial step size for the step toward the target. Default is 0.01.
+    source_step_convergance : float, optional
+        Convergence threshold for the source step. Default is 1e-7.
+    step_adaptation : float, optional
+        Factor to adapt the step sizes. Default is 1.5.
+    update_stats_every_k : int, optional
+        How often to update statistics used for step adaptation. Default is 10.
+    y_target : int | None, optional
+        Target label for targeted attack. If None, the attack is untargeted.
+        Default is None.
+    lb : float, optional
+        Lower bound for the input domain. Default is 0.0.
+    ub : float, optional
+        Upper bound for the input domain. Default is 1.0.
+    """
+
+    def __init__(
+        self,
+        init_attack: MinimizationAttack | None = None,
+        steps: int = 25000,
+        spherical_step: float = 0.01,
+        source_step: float = 0.01,
+        source_step_convergance: float = 1e-7,
+        step_adaptation: float = 1.5,
+        update_stats_every_k: int = 10,
+        y_target: int | None = None,
+        lb: float = 0.0,
+        ub: float = 1.0,
+        **kwargs,
+    ) -> None:
+        """Create Boundary Attack with Foolbox backend."""
+        foolbox_attack = BoundaryAttack(
+            init_attack=init_attack,
+            steps=steps,
+            spherical_step=spherical_step,
+            source_step=source_step,
+            source_step_convergance=source_step_convergance,
+            step_adaptation=step_adaptation,
+            update_stats_every_k=update_stats_every_k,
+        )
+
+        super().__init__(
+            foolbox_attack=foolbox_attack,
+            epsilon=None,
+            y_target=y_target,
+            lb=lb,
+            ub=ub,
+            **kwargs,
+        )
+
+    @staticmethod
+    def get_perturbation_models() -> set[str]:
+        """Check the perturbation models implemented for this attack."""
+        return {LpPerturbationModels.L2}

--- a/src/secmlt/adv/evasion/foolbox_attacks/foolbox_contrast_reduction.py
+++ b/src/secmlt/adv/evasion/foolbox_attacks/foolbox_contrast_reduction.py
@@ -1,0 +1,56 @@
+"""Wrapper of the Contrast Reduction attack implemented in Foolbox."""
+
+from __future__ import annotations
+
+from foolbox.attacks.contrast import L2ContrastReductionAttack
+from secmlt.adv.evasion.foolbox_attacks.foolbox_base import BaseFoolboxEvasionAttack
+from secmlt.adv.evasion.perturbation_models import LpPerturbationModels
+
+
+class ContrastReductionFoolbox(BaseFoolboxEvasionAttack):
+    """Wrapper of the Foolbox implementation of the Contrast Reduction attack.
+
+    Reduces the contrast of the input, moving every pixel towards the
+    ``target`` value, using an additive perturbation of the given L2 size.
+
+    Parameters
+    ----------
+    epsilon : float
+        Maximum L2 size of the contrast-reducing perturbation.
+    target : float, optional
+        Value towards which the pixels are moved when reducing the contrast.
+        Default is 0.5.
+    y_target : int | None, optional
+        Target label for targeted attack. If None, the attack is untargeted.
+        Default is None.
+    lb : float, optional
+        Lower bound for the input domain. Default is 0.0.
+    ub : float, optional
+        Upper bound for the input domain. Default is 1.0.
+    """
+
+    def __init__(
+        self,
+        epsilon: float,
+        target: float = 0.5,
+        y_target: int | None = None,
+        lb: float = 0.0,
+        ub: float = 1.0,
+        **kwargs,
+    ) -> None:
+        """Create Contrast Reduction attack with Foolbox backend."""
+        foolbox_attack = L2ContrastReductionAttack(target=target)
+
+        super().__init__(
+            foolbox_attack=foolbox_attack,
+            epsilon=epsilon,
+            y_target=y_target,
+            lb=lb,
+            ub=ub,
+            **kwargs,
+        )
+
+    @staticmethod
+    def get_perturbation_models() -> set[str]:
+        """Check the perturbation models implemented for this attack."""
+        return {LpPerturbationModels.L2}

--- a/src/secmlt/adv/evasion/foolbox_attacks/foolbox_cw.py
+++ b/src/secmlt/adv/evasion/foolbox_attacks/foolbox_cw.py
@@ -1,0 +1,70 @@
+"""Wrapper of the Carlini-Wagner attack implemented in Foolbox."""
+
+from __future__ import annotations
+
+from foolbox.attacks.carlini_wagner import L2CarliniWagnerAttack
+from secmlt.adv.evasion.foolbox_attacks.foolbox_base import BaseFoolboxEvasionAttack
+from secmlt.adv.evasion.perturbation_models import LpPerturbationModels
+
+
+class CWFoolbox(BaseFoolboxEvasionAttack):
+    """Wrapper of the Foolbox implementation of the Carlini-Wagner (CW) L2 attack.
+
+    Parameters
+    ----------
+        binary_search_steps : int
+            Number of binary search steps for the const parameter. Default is 9.
+        num_steps : int
+            Number of optimization iterations per binary search step. Default is 10000.
+        step_size : float
+            Learning rate for the Adam optimizer. Default is 0.01.
+        confidence : float
+            Confidence margin for adversarial examples. Default is 0.0.
+        initial_const : float
+            Initial value of the regularization constant. Default is 0.001.
+        abort_early : bool
+            Abort binary search early if no improvement is found. Default is True.
+        y_target : int | None, optional
+            Target label for the attack. If None, the attack is untargeted.
+        lb : float, optional
+            Lower bound for the perturbation. Default is 0.0.
+        ub : float, optional
+            Upper bound for the perturbation. Default is 1.0.
+    """
+
+    def __init__(
+        self,
+        binary_search_steps: int = 9,
+        num_steps: int = 10000,
+        step_size: float = 0.01,
+        confidence: float = 0.0,
+        initial_const: float = 0.001,
+        abort_early: bool = True,
+        y_target: int | None = None,
+        lb: float = 0.0,
+        ub: float = 1.0,
+        **kwargs,
+    ) -> None:
+        """Create CW L2 attack with Foolbox backend."""
+        foolbox_attack = L2CarliniWagnerAttack(
+            binary_search_steps=binary_search_steps,
+            steps=num_steps,
+            stepsize=step_size,
+            confidence=confidence,
+            initial_const=initial_const,
+            abort_early=abort_early,
+        )
+
+        super().__init__(
+            foolbox_attack=foolbox_attack,
+            epsilon=None,
+            y_target=y_target,
+            lb=lb,
+            ub=ub,
+            **kwargs,
+        )
+
+    @staticmethod
+    def get_perturbation_models() -> set[str]:
+        """Check the perturbation models implemented for this attack."""
+        return {LpPerturbationModels.L2}

--- a/src/secmlt/adv/evasion/foolbox_attacks/foolbox_deepfool.py
+++ b/src/secmlt/adv/evasion/foolbox_attacks/foolbox_deepfool.py
@@ -1,0 +1,63 @@
+"""Wrapper of the DeepFool attack implemented in Foolbox."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from foolbox.attacks.deepfool import L2DeepFoolAttack
+from secmlt.adv.evasion.foolbox_attacks.foolbox_base import BaseFoolboxEvasionAttack
+from secmlt.adv.evasion.perturbation_models import LpPerturbationModels
+
+
+class DeepFoolFoolbox(BaseFoolboxEvasionAttack):
+    """Wrapper of the Foolbox implementation of the DeepFool L2 attack.
+
+    Parameters
+    ----------
+        num_steps : int
+            Maximum number of steps to perform. Default is 50.
+        candidates : int | None, optional
+            Limit on the number of the most likely classes to consider.
+            Default is 10.
+        overshoot : float, optional
+            How much to overshoot the boundary. Default is 0.02.
+        loss : str, optional
+            Loss function to use inside the update step ('logits' or
+            'crossentropy'). Default is 'logits'.
+        lb : float, optional
+            Lower bound for the perturbation. Default is 0.0.
+        ub : float, optional
+            Upper bound for the perturbation. Default is 1.0.
+    """
+
+    def __init__(
+        self,
+        num_steps: int = 50,
+        candidates: int | None = 10,
+        overshoot: float = 0.02,
+        loss: Literal["logits", "crossentropy"] = "logits",
+        lb: float = 0.0,
+        ub: float = 1.0,
+        **kwargs,
+    ) -> None:
+        """Create DeepFool L2 attack with Foolbox backend."""
+        foolbox_attack = L2DeepFoolAttack(
+            steps=num_steps,
+            candidates=candidates,
+            overshoot=overshoot,
+            loss=loss,
+        )
+
+        super().__init__(
+            foolbox_attack=foolbox_attack,
+            epsilon=None,
+            y_target=None,
+            lb=lb,
+            ub=ub,
+            **kwargs,
+        )
+
+    @staticmethod
+    def get_perturbation_models() -> set[str]:
+        """Check the perturbation models implemented for this attack."""
+        return {LpPerturbationModels.L2}

--- a/src/secmlt/adv/evasion/foolbox_attacks/foolbox_fgsm.py
+++ b/src/secmlt/adv/evasion/foolbox_attacks/foolbox_fgsm.py
@@ -1,0 +1,72 @@
+"""Wrapper of the FGSM attack implemented in Foolbox."""
+
+from __future__ import annotations
+
+from foolbox.attacks.projected_gradient_descent import (
+    LinfProjectedGradientDescentAttack,
+)
+from secmlt.adv.evasion.foolbox_attacks.foolbox_base import BaseFoolboxEvasionAttack
+from secmlt.adv.evasion.perturbation_models import LpPerturbationModels
+
+
+class FGSMFoolbox(BaseFoolboxEvasionAttack):
+    """Wrapper of the Foolbox implementation of the FGSM attack."""
+
+    def __init__(
+        self,
+        perturbation_model: str,
+        epsilon: float,
+        y_target: int | None = None,
+        lb: float = 0.0,
+        ub: float = 1.0,
+        **kwargs,
+    ) -> None:
+        """
+        Create FGSM attack with Foolbox backend.
+
+        Parameters
+        ----------
+        perturbation_model : str
+            Perturbation model for the attack.
+        epsilon : float
+            Maximum perturbation allowed.
+        y_target : int | None, optional
+            Target label for the attack, None for untargeted, by default None.
+        lb : float, optional
+            Lower bound of the input space, by default 0.0.
+        ub : float, optional
+            Upper bound of the input space, by default 1.0.
+        """
+        perturbation_models = {
+            LpPerturbationModels.LINF: LinfProjectedGradientDescentAttack,
+        }
+        foolbox_attack_cls = perturbation_models.get(perturbation_model)
+
+        foolbox_attack = foolbox_attack_cls(
+            abs_stepsize=epsilon,
+            steps=1,
+            random_start=False,
+        )
+
+        super().__init__(
+            foolbox_attack=foolbox_attack,
+            epsilon=epsilon,
+            y_target=y_target,
+            lb=lb,
+            ub=ub,
+            **kwargs,
+        )
+
+    @staticmethod
+    def get_perturbation_models() -> set[str]:
+        """
+        Check the perturbation models implemented for this attack.
+
+        Returns
+        -------
+        set[str]
+            The list of perturbation models implemented for this attack.
+        """
+        return {
+            LpPerturbationModels.LINF,
+        }

--- a/src/secmlt/adv/evasion/foolbox_attacks/foolbox_gaussian_blur.py
+++ b/src/secmlt/adv/evasion/foolbox_attacks/foolbox_gaussian_blur.py
@@ -1,0 +1,67 @@
+"""Wrapper of the Gaussian Blur attack implemented in Foolbox."""
+
+from __future__ import annotations
+
+from foolbox.attacks.blur import GaussianBlurAttack
+from foolbox.distances import l2
+from secmlt.adv.evasion.foolbox_attacks.foolbox_base import BaseFoolboxEvasionAttack
+from secmlt.adv.evasion.perturbation_models import LpPerturbationModels
+
+
+class GaussianBlurFoolbox(BaseFoolboxEvasionAttack):
+    """Wrapper of the Foolbox implementation of the Gaussian Blur attack.
+
+    Decision-based attack that blurs the inputs with a Gaussian filter of
+    linearly increasing standard deviation until the input is misclassified,
+    minimizing the L2 norm of the resulting perturbation.
+
+    Parameters
+    ----------
+    steps : int, optional
+        Number of sigma values to try in the linear search. Default is 1000.
+    channel_axis : int | None, optional
+        Index of the channel axis. If None, it is inferred from the model.
+        Default is None.
+    max_sigma : float | None, optional
+        Maximum standard deviation of the Gaussian filter. If None, it is
+        derived from the input shape. Default is None.
+    y_target : int | None, optional
+        Target label for targeted attack. If None, the attack is untargeted.
+        Default is None.
+    lb : float, optional
+        Lower bound for the input domain. Default is 0.0.
+    ub : float, optional
+        Upper bound for the input domain. Default is 1.0.
+    """
+
+    def __init__(
+        self,
+        steps: int = 1000,
+        channel_axis: int | None = None,
+        max_sigma: float | None = None,
+        y_target: int | None = None,
+        lb: float = 0.0,
+        ub: float = 1.0,
+        **kwargs,
+    ) -> None:
+        """Create Gaussian Blur attack with Foolbox backend."""
+        foolbox_attack = GaussianBlurAttack(
+            distance=l2,
+            steps=steps,
+            channel_axis=channel_axis,
+            max_sigma=max_sigma,
+        )
+
+        super().__init__(
+            foolbox_attack=foolbox_attack,
+            epsilon=None,
+            y_target=y_target,
+            lb=lb,
+            ub=ub,
+            **kwargs,
+        )
+
+    @staticmethod
+    def get_perturbation_models() -> set[str]:
+        """Check the perturbation models implemented for this attack."""
+        return {LpPerturbationModels.L2}

--- a/src/secmlt/adv/evasion/foolbox_attacks/foolbox_hopskipjump.py
+++ b/src/secmlt/adv/evasion/foolbox_attacks/foolbox_hopskipjump.py
@@ -1,0 +1,91 @@
+"""Wrapper of the HopSkipJump Attack implemented in Foolbox."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+from foolbox.attacks.hop_skip_jump import HopSkipJumpAttack
+from secmlt.adv.evasion.foolbox_attacks.foolbox_base import BaseFoolboxEvasionAttack
+from secmlt.adv.evasion.perturbation_models import LpPerturbationModels
+
+if TYPE_CHECKING:
+    from foolbox.attacks.base import MinimizationAttack
+
+
+class HopSkipJumpFoolbox(BaseFoolboxEvasionAttack):
+    """Wrapper of the Foolbox implementation of the HopSkipJump Attack.
+
+    Parameters
+    ----------
+    perturbation_model : str, optional
+        Norm constraint for the attack. Either L2 or Linf.
+        Default is L2.
+    init_attack : MinimizationAttack | None, optional
+        Attack used to find an initial adversarial example. If None, Foolbox
+        falls back to LinearSearchBlendedUniformNoiseAttack. Default is None.
+    steps : int, optional
+        Number of steps. Default is 64.
+    initial_gradient_eval_steps : int, optional
+        Initial number of gradient evaluations per step. Default is 100.
+    max_gradient_eval_steps : int, optional
+        Maximum number of gradient evaluations per step. Default is 10000.
+    stepsize_search : str, optional
+        Strategy for step-size search. Either "geometric_progression" or
+        "grid_search". Default is "geometric_progression".
+    gamma : float, optional
+        Factor controlling the step-size growth. Default is 1.0.
+    y_target : int | None, optional
+        Target label for targeted attack. If None, the attack is untargeted.
+        Default is None.
+    lb : float, optional
+        Lower bound for the input domain. Default is 0.0.
+    ub : float, optional
+        Upper bound for the input domain. Default is 1.0.
+    """
+
+    _CONSTRAINT_MAP = {
+        LpPerturbationModels.L2: "l2",
+        LpPerturbationModels.LINF: "linf",
+    }
+
+    def __init__(
+        self,
+        perturbation_model: str = LpPerturbationModels.L2,
+        init_attack: MinimizationAttack | None = None,
+        steps: int = 64,
+        initial_gradient_eval_steps: int = 100,
+        max_gradient_eval_steps: int = 10000,
+        stepsize_search: Literal[
+            "geometric_progression", "grid_search"
+        ] = "geometric_progression",
+        gamma: float = 1.0,
+        y_target: int | None = None,
+        lb: float = 0.0,
+        ub: float = 1.0,
+        **kwargs,
+    ) -> None:
+        """Create HopSkipJump Attack with Foolbox backend."""
+        constraint = self._CONSTRAINT_MAP[perturbation_model]
+        foolbox_attack = HopSkipJumpAttack(
+            init_attack=init_attack,
+            steps=steps,
+            initial_gradient_eval_steps=initial_gradient_eval_steps,
+            max_gradient_eval_steps=max_gradient_eval_steps,
+            stepsize_search=stepsize_search,
+            gamma=gamma,
+            constraint=constraint,
+        )
+
+        super().__init__(
+            foolbox_attack=foolbox_attack,
+            epsilon=None,
+            y_target=y_target,
+            lb=lb,
+            ub=ub,
+            **kwargs,
+        )
+
+    @staticmethod
+    def get_perturbation_models() -> set[str]:
+        """Check the perturbation models implemented for this attack."""
+        return {LpPerturbationModels.L2, LpPerturbationModels.LINF}

--- a/src/secmlt/adv/evasion/foolbox_attacks/foolbox_hopskipjump.py
+++ b/src/secmlt/adv/evasion/foolbox_attacks/foolbox_hopskipjump.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, ClassVar, Literal
 
 from foolbox.attacks.hop_skip_jump import HopSkipJumpAttack
 from secmlt.adv.evasion.foolbox_attacks.foolbox_base import BaseFoolboxEvasionAttack
@@ -43,7 +43,7 @@ class HopSkipJumpFoolbox(BaseFoolboxEvasionAttack):
         Upper bound for the input domain. Default is 1.0.
     """
 
-    _CONSTRAINT_MAP = {
+    _CONSTRAINT_MAP: ClassVar[dict[str, str]] = {
         LpPerturbationModels.L2: "l2",
         LpPerturbationModels.LINF: "linf",
     }

--- a/src/secmlt/adv/evasion/foolbox_attacks/foolbox_saltandpepper.py
+++ b/src/secmlt/adv/evasion/foolbox_attacks/foolbox_saltandpepper.py
@@ -1,0 +1,65 @@
+"""Wrapper of the Salt & Pepper Noise attack implemented in Foolbox."""
+
+from __future__ import annotations
+
+from foolbox.attacks.saltandpepper import SaltAndPepperNoiseAttack
+from secmlt.adv.evasion.foolbox_attacks.foolbox_base import BaseFoolboxEvasionAttack
+from secmlt.adv.evasion.perturbation_models import LpPerturbationModels
+
+
+class SaltAndPepperNoiseFoolbox(BaseFoolboxEvasionAttack):
+    """Wrapper of the Foolbox implementation of the Salt & Pepper Noise attack.
+
+    Decision-based attack that increasingly replaces pixels with salt (maximum)
+    and pepper (minimum) values until the input is misclassified, minimizing
+    the L2 norm of the resulting perturbation.
+
+    Parameters
+    ----------
+    steps : int, optional
+        Number of steps to run. Default is 1000.
+    across_channels : bool, optional
+        If True, the same salt/pepper mask is applied across all channels of a
+        pixel. If False, channels are perturbed independently. Default is True.
+    channel_axis : int | None, optional
+        Index of the channel axis. If None, it is inferred from the model.
+        Default is None.
+    y_target : int | None, optional
+        Target label for targeted attack. If None, the attack is untargeted.
+        Default is None.
+    lb : float, optional
+        Lower bound for the input domain. Default is 0.0.
+    ub : float, optional
+        Upper bound for the input domain. Default is 1.0.
+    """
+
+    def __init__(
+        self,
+        steps: int = 1000,
+        across_channels: bool = True,
+        channel_axis: int | None = None,
+        y_target: int | None = None,
+        lb: float = 0.0,
+        ub: float = 1.0,
+        **kwargs,
+    ) -> None:
+        """Create Salt & Pepper Noise attack with Foolbox backend."""
+        foolbox_attack = SaltAndPepperNoiseAttack(
+            steps=steps,
+            across_channels=across_channels,
+            channel_axis=channel_axis,
+        )
+
+        super().__init__(
+            foolbox_attack=foolbox_attack,
+            epsilon=None,
+            y_target=y_target,
+            lb=lb,
+            ub=ub,
+            **kwargs,
+        )
+
+    @staticmethod
+    def get_perturbation_models() -> set[str]:
+        """Check the perturbation models implemented for this attack."""
+        return {LpPerturbationModels.L2}

--- a/src/secmlt/adv/evasion/foolbox_attacks/foolbox_spatial.py
+++ b/src/secmlt/adv/evasion/foolbox_attacks/foolbox_spatial.py
@@ -1,0 +1,79 @@
+"""Wrapper of the Spatial Attack implemented in Foolbox."""
+
+from __future__ import annotations
+
+from foolbox.attacks.spatial_attack import SpatialAttack
+from secmlt.adv.evasion.foolbox_attacks.foolbox_base import BaseFoolboxEvasionAttack
+
+
+class SpatialAttackFoolbox(BaseFoolboxEvasionAttack):
+    """Wrapper of the Foolbox implementation of the Spatial Attack.
+
+    Parameters
+    ----------
+    max_translation : float, optional
+        Maximum translation in any direction. Default is 3.
+    max_rotation : float, optional
+        Maximum rotation in degrees. Default is 30.
+    num_translations : int, optional
+        Number of translations to try in the grid search (per axis).
+        Only used when ``grid_search`` is True. Default is 5.
+    num_rotations : int, optional
+        Number of rotations to try in the grid search. Only used when
+        ``grid_search`` is True. Default is 5.
+    grid_search : bool, optional
+        If True, perform a grid search over the translation/rotation space.
+        If False, perform a random search. Default is True.
+    random_steps : int, optional
+        Number of random search steps. Only used when ``grid_search`` is
+        False. Default is 100.
+    y_target : int | None, optional
+        Target label for targeted attack. If None, the attack is untargeted.
+        Default is None.
+    lb : float, optional
+        Lower bound for the input domain. Default is 0.0.
+    ub : float, optional
+        Upper bound for the input domain. Default is 1.0.
+    """
+
+    def __init__(
+        self,
+        max_translation: float = 3,
+        max_rotation: float = 30,
+        num_translations: int = 5,
+        num_rotations: int = 5,
+        grid_search: bool = True,
+        random_steps: int = 100,
+        y_target: int | None = None,
+        lb: float = 0.0,
+        ub: float = 1.0,
+        **kwargs,
+    ) -> None:
+        """Create Spatial Attack with Foolbox backend."""
+        foolbox_attack = SpatialAttack(
+            max_translation=max_translation,
+            max_rotation=max_rotation,
+            num_translations=num_translations,
+            num_rotations=num_rotations,
+            grid_search=grid_search,
+            random_steps=random_steps,
+        )
+
+        super().__init__(
+            foolbox_attack=foolbox_attack,
+            epsilon=None,
+            y_target=y_target,
+            lb=lb,
+            ub=ub,
+            **kwargs,
+        )
+
+    @staticmethod
+    def get_perturbation_models() -> set[str]:
+        """Check the perturbation models implemented for this attack.
+
+        The Spatial Attack applies rotations and translations rather than
+        additive Lp-bounded perturbations, so no Lp perturbation model
+        applies.
+        """
+        return set()

--- a/src/secmlt/adv/evasion/foolbox_attacks/foolbox_vat.py
+++ b/src/secmlt/adv/evasion/foolbox_attacks/foolbox_vat.py
@@ -1,0 +1,53 @@
+"""Wrapper of the Virtual Adversarial Attack implemented in Foolbox."""
+
+from __future__ import annotations
+
+from foolbox.attacks.virtual_adversarial_attack import VirtualAdversarialAttack
+from secmlt.adv.evasion.foolbox_attacks.foolbox_base import BaseFoolboxEvasionAttack
+from secmlt.adv.evasion.perturbation_models import LpPerturbationModels
+
+
+class VATFoolbox(BaseFoolboxEvasionAttack):
+    """Wrapper of the Foolbox implementation of the Virtual Adversarial Attack.
+
+    Parameters
+    ----------
+    epsilon : float
+        Maximum L2 perturbation allowed.
+    steps : int, optional
+        Number of update steps for the approximated second-order optimization.
+        Default is 1.
+    xi : float, optional
+        L2 distance between original image and first adversarial proposal.
+        Default is 1e-6.
+    lb : float, optional
+        Lower bound for the input domain. Default is 0.0.
+    ub : float, optional
+        Upper bound for the input domain. Default is 1.0.
+    """
+
+    def __init__(
+        self,
+        epsilon: float,
+        steps: int = 1,
+        xi: float = 1e-6,
+        lb: float = 0.0,
+        ub: float = 1.0,
+        **kwargs,
+    ) -> None:
+        """Create Virtual Adversarial Attack with Foolbox backend."""
+        foolbox_attack = VirtualAdversarialAttack(steps=steps, xi=xi)
+
+        super().__init__(
+            foolbox_attack=foolbox_attack,
+            epsilon=epsilon,
+            y_target=None,
+            lb=lb,
+            ub=ub,
+            **kwargs,
+        )
+
+    @staticmethod
+    def get_perturbation_models() -> set[str]:
+        """Check the perturbation models implemented for this attack."""
+        return {LpPerturbationModels.L2}

--- a/src/secmlt/adv/evasion/gaussian_blur.py
+++ b/src/secmlt/adv/evasion/gaussian_blur.py
@@ -1,0 +1,96 @@
+"""Gaussian Blur attack implementation (Foolbox-only backend)."""
+
+from __future__ import annotations
+
+import importlib.util
+from typing import TYPE_CHECKING
+
+from secmlt.adv.backends import Backends
+from secmlt.adv.evasion.base_evasion_attack import (
+    BaseEvasionAttack,
+    BaseEvasionAttackCreator,
+)
+
+if TYPE_CHECKING:
+    from secmlt.trackers.trackers import Tracker
+
+
+class GaussianBlur(BaseEvasionAttackCreator):
+    """Creator for the decision-based Gaussian Blur attack."""
+
+    def __new__(
+        cls,
+        steps: int = 1000,
+        channel_axis: int | None = None,
+        max_sigma: float | None = None,
+        y_target: int | None = None,
+        lb: float = 0.0,
+        ub: float = 1.0,
+        backend: str = Backends.FOOLBOX,
+        trackers: list[Tracker] | None = None,
+        **kwargs,
+    ) -> BaseEvasionAttack:
+        """
+        Create the Gaussian Blur attack.
+
+        Decision-based attack that blurs the inputs with a Gaussian filter of
+        linearly increasing standard deviation until the input is
+        misclassified, minimizing the L2 norm of the resulting perturbation.
+
+        Parameters
+        ----------
+        steps : int, optional
+            Number of sigma values to try in the linear search.
+            Default is 1000.
+        channel_axis : int | None, optional
+            Index of the channel axis. If None, it is inferred from the model.
+            Default is None.
+        max_sigma : float | None, optional
+            Maximum standard deviation of the Gaussian filter. If None, it is
+            derived from the input shape. Default is None.
+        y_target : int | None, optional
+            Target label for targeted attack. If None, the attack is
+            untargeted. Default is None.
+        lb : float, optional
+            Lower bound for the input domain. Default is 0.0.
+        ub : float, optional
+            Upper bound for the input domain. Default is 1.0.
+        backend : str, optional
+            Backend to use. Only Backends.FOOLBOX is supported.
+            Default is Backends.FOOLBOX.
+        trackers : list[Tracker] | None, optional
+            Trackers for monitoring attack metrics, by default None.
+
+        Returns
+        -------
+        BaseEvasionAttack
+            Gaussian Blur attack instance.
+        """
+        cls.check_backend_available(backend)
+        implementation = cls.get_implementation(backend)
+        return implementation(
+            steps=steps,
+            channel_axis=channel_axis,
+            max_sigma=max_sigma,
+            y_target=y_target,
+            lb=lb,
+            ub=ub,
+            trackers=trackers,
+            **kwargs,
+        )
+
+    @staticmethod
+    def get_backends() -> list[str]:
+        """Get available implementations for the Gaussian Blur attack."""
+        return [Backends.FOOLBOX]
+
+    @staticmethod
+    def _get_foolbox_implementation() -> type[GaussianBlurFoolbox]:  # noqa: F821
+        if importlib.util.find_spec("foolbox", None) is not None:
+            from secmlt.adv.evasion.foolbox_attacks.foolbox_gaussian_blur import (
+                GaussianBlurFoolbox,
+            )
+
+            return GaussianBlurFoolbox
+        msg = "foolbox extra not installed"
+        raise ImportError(msg)

--- a/src/secmlt/adv/evasion/hopskipjump.py
+++ b/src/secmlt/adv/evasion/hopskipjump.py
@@ -1,0 +1,119 @@
+"""HopSkipJump attack implementation (Foolbox-only backend)."""
+
+from __future__ import annotations
+
+import importlib.util
+from typing import TYPE_CHECKING, Literal
+
+from secmlt.adv.backends import Backends
+from secmlt.adv.evasion.base_evasion_attack import (
+    BaseEvasionAttack,
+    BaseEvasionAttackCreator,
+)
+from secmlt.adv.evasion.perturbation_models import LpPerturbationModels
+
+if TYPE_CHECKING:
+    from foolbox.attacks.base import MinimizationAttack
+    from secmlt.trackers.trackers import Tracker
+
+
+class HopSkipJump(BaseEvasionAttackCreator):
+    """Creator for the decision-based HopSkipJump Attack."""
+
+    def __new__(
+        cls,
+        perturbation_model: str = LpPerturbationModels.L2,
+        init_attack: MinimizationAttack | None = None,
+        steps: int = 64,
+        initial_gradient_eval_steps: int = 100,
+        max_gradient_eval_steps: int = 10000,
+        stepsize_search: Literal[
+            "geometric_progression", "grid_search"
+        ] = "geometric_progression",
+        gamma: float = 1.0,
+        y_target: int | None = None,
+        lb: float = 0.0,
+        ub: float = 1.0,
+        backend: str = Backends.FOOLBOX,
+        trackers: list[Tracker] | None = None,
+        **kwargs,
+    ) -> BaseEvasionAttack:
+        """
+        Create the HopSkipJump Attack.
+
+        References
+        ----------
+        .. [#Chen19] Jianbo Chen, Michael I. Jordan, Martin J. Wainwright,
+            "HopSkipJumpAttack: A Query-Efficient Decision-Based Attack",
+            https://arxiv.org/abs/1904.02144
+
+        Parameters
+        ----------
+        perturbation_model : str, optional
+            Norm constraint for the attack. Either L2 or Linf.
+            Default is L2.
+        init_attack : MinimizationAttack | None, optional
+            Attack used to find an initial adversarial example. If None,
+            Foolbox falls back to LinearSearchBlendedUniformNoiseAttack.
+            Default is None.
+        steps : int, optional
+            Number of steps. Default is 64.
+        initial_gradient_eval_steps : int, optional
+            Initial number of gradient evaluations per step. Default is 100.
+        max_gradient_eval_steps : int, optional
+            Maximum number of gradient evaluations per step. Default is 10000.
+        stepsize_search : str, optional
+            Strategy for step-size search. Either "geometric_progression" or
+            "grid_search". Default is "geometric_progression".
+        gamma : float, optional
+            Factor controlling the step-size growth. Default is 1.0.
+        y_target : int | None, optional
+            Target label for targeted attack. If None, the attack is
+            untargeted. Default is None.
+        lb : float, optional
+            Lower bound for the input domain. Default is 0.0.
+        ub : float, optional
+            Upper bound for the input domain. Default is 1.0.
+        backend : str, optional
+            Backend to use. Only Backends.FOOLBOX is supported.
+            Default is Backends.FOOLBOX.
+        trackers : list[Tracker] | None, optional
+            Trackers for monitoring attack metrics, by default None.
+
+        Returns
+        -------
+        BaseEvasionAttack
+            HopSkipJump attack instance.
+        """
+        cls.check_backend_available(backend)
+        implementation = cls.get_implementation(backend)
+        return implementation(
+            perturbation_model=perturbation_model,
+            init_attack=init_attack,
+            steps=steps,
+            initial_gradient_eval_steps=initial_gradient_eval_steps,
+            max_gradient_eval_steps=max_gradient_eval_steps,
+            stepsize_search=stepsize_search,
+            gamma=gamma,
+            y_target=y_target,
+            lb=lb,
+            ub=ub,
+            trackers=trackers,
+            **kwargs,
+        )
+
+    @staticmethod
+    def get_backends() -> list[str]:
+        """Get available implementations for the HopSkipJump attack."""
+        return [Backends.FOOLBOX]
+
+    @staticmethod
+    def _get_foolbox_implementation() -> type[HopSkipJumpFoolbox]:  # noqa: F821
+        if importlib.util.find_spec("foolbox", None) is not None:
+            from secmlt.adv.evasion.foolbox_attacks.foolbox_hopskipjump import (
+                HopSkipJumpFoolbox,
+            )
+
+            return HopSkipJumpFoolbox
+        msg = "foolbox extra not installed"
+        raise ImportError(msg)

--- a/src/secmlt/adv/evasion/saltandpepper.py
+++ b/src/secmlt/adv/evasion/saltandpepper.py
@@ -1,0 +1,96 @@
+"""Salt & Pepper Noise attack implementation (Foolbox-only backend)."""
+
+from __future__ import annotations
+
+import importlib.util
+from typing import TYPE_CHECKING
+
+from secmlt.adv.backends import Backends
+from secmlt.adv.evasion.base_evasion_attack import (
+    BaseEvasionAttack,
+    BaseEvasionAttackCreator,
+)
+
+if TYPE_CHECKING:
+    from secmlt.trackers.trackers import Tracker
+
+
+class SaltAndPepperNoise(BaseEvasionAttackCreator):
+    """Creator for the decision-based Salt & Pepper Noise attack."""
+
+    def __new__(
+        cls,
+        steps: int = 1000,
+        across_channels: bool = True,
+        channel_axis: int | None = None,
+        y_target: int | None = None,
+        lb: float = 0.0,
+        ub: float = 1.0,
+        backend: str = Backends.FOOLBOX,
+        trackers: list[Tracker] | None = None,
+        **kwargs,
+    ) -> BaseEvasionAttack:
+        """
+        Create the Salt & Pepper Noise attack.
+
+        Decision-based attack that increasingly replaces pixels with salt
+        (maximum) and pepper (minimum) values until the input is misclassified,
+        minimizing the L2 norm of the resulting perturbation.
+
+        Parameters
+        ----------
+        steps : int, optional
+            Number of steps to run. Default is 1000.
+        across_channels : bool, optional
+            If True, the same salt/pepper mask is applied across all channels
+            of a pixel. If False, channels are perturbed independently.
+            Default is True.
+        channel_axis : int | None, optional
+            Index of the channel axis. If None, it is inferred from the model.
+            Default is None.
+        y_target : int | None, optional
+            Target label for targeted attack. If None, the attack is
+            untargeted. Default is None.
+        lb : float, optional
+            Lower bound for the input domain. Default is 0.0.
+        ub : float, optional
+            Upper bound for the input domain. Default is 1.0.
+        backend : str, optional
+            Backend to use. Only Backends.FOOLBOX is supported.
+            Default is Backends.FOOLBOX.
+        trackers : list[Tracker] | None, optional
+            Trackers for monitoring attack metrics, by default None.
+
+        Returns
+        -------
+        BaseEvasionAttack
+            Salt & Pepper Noise attack instance.
+        """
+        cls.check_backend_available(backend)
+        implementation = cls.get_implementation(backend)
+        return implementation(
+            steps=steps,
+            across_channels=across_channels,
+            channel_axis=channel_axis,
+            y_target=y_target,
+            lb=lb,
+            ub=ub,
+            trackers=trackers,
+            **kwargs,
+        )
+
+    @staticmethod
+    def get_backends() -> list[str]:
+        """Get available implementations for the Salt & Pepper Noise attack."""
+        return [Backends.FOOLBOX]
+
+    @staticmethod
+    def _get_foolbox_implementation() -> type[SaltAndPepperNoiseFoolbox]:  # noqa: F821
+        if importlib.util.find_spec("foolbox", None) is not None:
+            from secmlt.adv.evasion.foolbox_attacks.foolbox_saltandpepper import (
+                SaltAndPepperNoiseFoolbox,
+            )
+
+            return SaltAndPepperNoiseFoolbox
+        msg = "foolbox extra not installed"
+        raise ImportError(msg)

--- a/src/secmlt/adv/evasion/spatial_attack.py
+++ b/src/secmlt/adv/evasion/spatial_attack.py
@@ -1,0 +1,112 @@
+"""Spatial Attack implementation (Foolbox-only backend)."""
+
+from __future__ import annotations
+
+import importlib.util
+from typing import TYPE_CHECKING
+
+from secmlt.adv.backends import Backends
+from secmlt.adv.evasion.base_evasion_attack import (
+    BaseEvasionAttack,
+    BaseEvasionAttackCreator,
+)
+
+if TYPE_CHECKING:
+    from secmlt.trackers.trackers import Tracker
+
+
+class SpatialAttack(BaseEvasionAttackCreator):
+    """Creator for the Spatial Attack."""
+
+    def __new__(
+        cls,
+        max_translation: float = 3,
+        max_rotation: float = 30,
+        num_translations: int = 5,
+        num_rotations: int = 5,
+        grid_search: bool = True,
+        random_steps: int = 100,
+        y_target: int | None = None,
+        lb: float = 0.0,
+        ub: float = 1.0,
+        backend: str = Backends.FOOLBOX,
+        trackers: list[Tracker] | None = None,
+        **kwargs,
+    ) -> BaseEvasionAttack:
+        """
+        Create the Spatial Attack.
+
+        References
+        ----------
+        .. [#Engs19] Logan Engstrom, Brandon Tran, Dimitris Tsipras,
+            Ludwig Schmidt, Aleksander Madry,
+            "Exploring the Landscape of Spatial Robustness",
+            https://arxiv.org/abs/1712.02779
+
+        Parameters
+        ----------
+        max_translation : float, optional
+            Maximum translation in any direction. Default is 3.
+        max_rotation : float, optional
+            Maximum rotation in degrees. Default is 30.
+        num_translations : int, optional
+            Number of translations to try in the grid search (per axis).
+            Only used when ``grid_search`` is True. Default is 5.
+        num_rotations : int, optional
+            Number of rotations to try in the grid search. Only used when
+            ``grid_search`` is True. Default is 5.
+        grid_search : bool, optional
+            If True, perform a grid search over the translation/rotation
+            space. If False, perform a random search. Default is True.
+        random_steps : int, optional
+            Number of random search steps. Only used when ``grid_search``
+            is False. Default is 100.
+        y_target : int | None, optional
+            Target label for targeted attack. If None, the attack is
+            untargeted. Default is None.
+        lb : float, optional
+            Lower bound for the input domain. Default is 0.0.
+        ub : float, optional
+            Upper bound for the input domain. Default is 1.0.
+        backend : str, optional
+            Backend to use. Only Backends.FOOLBOX is supported.
+            Default is Backends.FOOLBOX.
+        trackers : list[Tracker] | None, optional
+            Trackers for monitoring attack metrics, by default None.
+
+        Returns
+        -------
+        BaseEvasionAttack
+            Spatial Attack instance.
+        """
+        cls.check_backend_available(backend)
+        implementation = cls.get_implementation(backend)
+        return implementation(
+            max_translation=max_translation,
+            max_rotation=max_rotation,
+            num_translations=num_translations,
+            num_rotations=num_rotations,
+            grid_search=grid_search,
+            random_steps=random_steps,
+            y_target=y_target,
+            lb=lb,
+            ub=ub,
+            trackers=trackers,
+            **kwargs,
+        )
+
+    @staticmethod
+    def get_backends() -> list[str]:
+        """Get available implementations for the Spatial Attack."""
+        return [Backends.FOOLBOX]
+
+    @staticmethod
+    def _get_foolbox_implementation() -> type[SpatialAttackFoolbox]:  # noqa: F821
+        if importlib.util.find_spec("foolbox", None) is not None:
+            from secmlt.adv.evasion.foolbox_attacks.foolbox_spatial import (
+                SpatialAttackFoolbox,
+            )
+
+            return SpatialAttackFoolbox
+        msg = "foolbox extra not installed"
+        raise ImportError(msg)

--- a/src/secmlt/adv/evasion/vat.py
+++ b/src/secmlt/adv/evasion/vat.py
@@ -1,0 +1,89 @@
+"""Virtual Adversarial Training (VAT) attack implementation."""
+
+from __future__ import annotations
+
+import importlib.util
+from typing import TYPE_CHECKING
+
+from secmlt.adv.backends import Backends
+from secmlt.adv.evasion.base_evasion_attack import (
+    BaseEvasionAttack,
+    BaseEvasionAttackCreator,
+)
+
+if TYPE_CHECKING:
+    from secmlt.trackers.trackers import Tracker
+
+
+class VAT(BaseEvasionAttackCreator):
+    """Creator for the Virtual Adversarial Training attack."""
+
+    def __new__(
+        cls,
+        epsilon: float,
+        steps: int = 1,
+        xi: float = 1e-6,
+        lb: float = 0.0,
+        ub: float = 1.0,
+        backend: str = Backends.FOOLBOX,
+        trackers: list[Tracker] | None = None,
+        **kwargs,
+    ) -> BaseEvasionAttack:
+        """
+        Create the Virtual Adversarial Training attack.
+
+        References
+        ----------
+        .. [#Miy15] Takeru Miyato, Shin-ichi Maeda, Masanori Koyama, Ken Nakae,
+            Shin Ishii, "Distributional Smoothing with Virtual Adversarial
+            Training", https://arxiv.org/abs/1507.00677
+
+        Parameters
+        ----------
+        epsilon : float
+            Maximum L2 perturbation allowed.
+        steps : int, optional
+            Number of update steps for the approximated second-order
+            optimization. Default is 1.
+        xi : float, optional
+            L2 distance between original image and first adversarial
+            proposal. Default is 1e-6.
+        lb : float, optional
+            Lower bound for the input domain. Default is 0.0.
+        ub : float, optional
+            Upper bound for the input domain. Default is 1.0.
+        backend : str, optional
+            Backend to use to run the attack. Default is Backends.FOOLBOX.
+        trackers : list[Tracker] | None, optional
+            Trackers for monitoring attack metrics, by default None.
+
+        Returns
+        -------
+        BaseEvasionAttack
+            VAT attack instance.
+        """
+        cls.check_backend_available(backend)
+        implementation = cls.get_implementation(backend)
+        return implementation(
+            epsilon=epsilon,
+            steps=steps,
+            xi=xi,
+            lb=lb,
+            ub=ub,
+            trackers=trackers,
+            **kwargs,
+        )
+
+    @staticmethod
+    def get_backends() -> list[str]:
+        """Get available implementations for the VAT attack."""
+        return [Backends.FOOLBOX]
+
+    @staticmethod
+    def _get_foolbox_implementation() -> type[VATFoolbox]:  # noqa: F821
+        if importlib.util.find_spec("foolbox", None) is not None:
+            from secmlt.adv.evasion.foolbox_attacks.foolbox_vat import VATFoolbox
+
+            return VATFoolbox
+        msg = "foolbox extra not installed"
+        raise ImportError(msg)

--- a/src/secmlt/tests/test_attacks.py
+++ b/src/secmlt/tests/test_attacks.py
@@ -5,6 +5,7 @@ from secmlt.adv.evasion.advlib_attacks.advlib_fgsm import FGSMAdvLib
 from secmlt.adv.evasion.advlib_attacks.advlib_fmn import FMNAdvLib
 from secmlt.adv.evasion.advlib_attacks.advlib_pgd import PGDAdvLib
 from secmlt.adv.evasion.base_evasion_attack import BaseEvasionAttack
+from secmlt.adv.evasion.cw import CW
 from secmlt.adv.evasion.ddn import DDN
 from secmlt.adv.evasion.fgsm import FGSM
 from secmlt.adv.evasion.fmn import FMN, FMNNative
@@ -544,3 +545,32 @@ def test_modular_attack_accepts_custom_loss_instance():
 
     assert attack.loss_function is custom_loss
     assert attack.loss_function.reduction == "mean"
+
+
+@pytest.mark.parametrize(
+    "y_target",
+    [None, 1],
+)
+@pytest.mark.parametrize(
+    ("backend",),
+    [
+        ("foolbox",),
+        ("advlib",),
+    ],
+)
+def test_cw_attack(
+    backend,
+    y_target,
+    model,
+    data_loader,
+) -> None:
+    attack = CW(
+        binary_search_steps=2,
+        num_steps=10,
+        step_size=0.01,
+        confidence=0.0,
+        initial_const=0.001,
+        y_target=y_target,
+        backend=backend,
+    )
+    assert isinstance(attack(model, data_loader), DataLoader)

--- a/src/secmlt/tests/test_attacks.py
+++ b/src/secmlt/tests/test_attacks.py
@@ -54,20 +54,6 @@ from torch.utils.data import DataLoader
 
 PGDEoT = type("PGDEoT", (EoTGradientMixin, PGDNative), {})
 
-
-def _adv_lib_gte(major: int, minor: int, patch: int) -> bool:
-    try:
-        version_str = importlib.metadata.version("adv-lib")
-    except importlib.metadata.PackageNotFoundError:
-        return False
-    else:
-        parts = tuple(int(x) for x in version_str.split(".")[:3])
-        return parts >= (major, minor, patch)
-
-
-adv_lib_gte_023 = _adv_lib_gte(0, 2, 3)
-
-
 class IdentityGradientProcessingMock(GradientProcessing):
     def __call__(self, grad: torch.Tensor) -> torch.Tensor:
         return grad
@@ -617,13 +603,7 @@ def test_cw_attack(
     ("backend",),
     [
         ("foolbox",),
-        pytest.param(
-            "advlib",
-            marks=pytest.mark.skipif(
-                not adv_lib_gte_023,
-                reason="adv_lib >= 0.2.3 required for DeepFool advlib backend",
-            ),
-        ),
+        ("advlib",),
     ],
 )
 def test_deepfool_attack(

--- a/src/secmlt/tests/test_attacks.py
+++ b/src/secmlt/tests/test_attacks.py
@@ -1,15 +1,18 @@
 import pytest
 import torch
 from secmlt.adv.evasion.advlib_attacks.advlib_base import BaseAdvLibEvasionAttack
+from secmlt.adv.evasion.advlib_attacks.advlib_deepfool import DeepFoolAdvLib
 from secmlt.adv.evasion.advlib_attacks.advlib_fgsm import FGSMAdvLib
 from secmlt.adv.evasion.advlib_attacks.advlib_fmn import FMNAdvLib
 from secmlt.adv.evasion.advlib_attacks.advlib_pgd import PGDAdvLib
 from secmlt.adv.evasion.base_evasion_attack import BaseEvasionAttack
 from secmlt.adv.evasion.cw import CW
 from secmlt.adv.evasion.ddn import DDN
+from secmlt.adv.evasion.deepfool import DeepFool
 from secmlt.adv.evasion.fgsm import FGSM
 from secmlt.adv.evasion.fmn import FMN, FMNNative
 from secmlt.adv.evasion.foolbox_attacks.foolbox_base import BaseFoolboxEvasionAttack
+from secmlt.adv.evasion.foolbox_attacks.foolbox_deepfool import DeepFoolFoolbox
 from secmlt.adv.evasion.foolbox_attacks.foolbox_fgsm import FGSMFoolbox
 from secmlt.adv.evasion.foolbox_attacks.foolbox_fmn import FMNFoolbox
 from secmlt.adv.evasion.foolbox_attacks.foolbox_pgd import PGDFoolbox
@@ -571,6 +574,26 @@ def test_cw_attack(
         confidence=0.0,
         initial_const=0.001,
         y_target=y_target,
+        backend=backend,
+    )
+    assert isinstance(attack(model, data_loader), DataLoader)
+
+
+@pytest.mark.parametrize(
+    ("backend",),
+    [
+        ("foolbox",),
+        ("advlib",),
+    ],
+)
+def test_deepfool_attack(
+    backend,
+    model,
+    data_loader,
+) -> None:
+    attack = DeepFool(
+        num_steps=10,
+        overshoot=0.02,
         backend=backend,
     )
     assert isinstance(attack(model, data_loader), DataLoader)

--- a/src/secmlt/tests/test_attacks.py
+++ b/src/secmlt/tests/test_attacks.py
@@ -1,3 +1,5 @@
+import importlib.metadata
+
 import pytest
 import torch
 from secmlt.adv.evasion.advlib_attacks.advlib_base import BaseAdvLibEvasionAttack
@@ -33,6 +35,18 @@ from secmlt.trackers.trackers import LossTracker
 from torch.utils.data import DataLoader
 
 PGDEoT = type("PGDEoT", (EoTGradientMixin, PGDNative), {})
+
+def _adv_lib_gte(major: int, minor: int, patch: int) -> bool:
+    try:
+        version_str = importlib.metadata.version("adv-lib")
+    except importlib.metadata.PackageNotFoundError:
+        return False
+    else:
+        parts = tuple(int(x) for x in version_str.split(".")[:3])
+        return parts >= (major, minor, patch)
+
+
+adv_lib_gte_023 = _adv_lib_gte(0, 2, 3)
 
 
 class IdentityGradientProcessingMock(GradientProcessing):
@@ -584,7 +598,13 @@ def test_cw_attack(
     ("backend",),
     [
         ("foolbox",),
-        ("advlib",),
+        pytest.param(
+            "advlib",
+            marks=pytest.mark.skipif(
+                not adv_lib_gte_023,
+                reason="adv_lib >= 0.2.3 required for DeepFool advlib backend",
+            ),
+        ),
     ],
 )
 def test_deepfool_attack(

--- a/src/secmlt/tests/test_attacks.py
+++ b/src/secmlt/tests/test_attacks.py
@@ -5,12 +5,14 @@ from secmlt.adv.evasion.advlib_attacks.advlib_fgsm import FGSMAdvLib
 from secmlt.adv.evasion.advlib_attacks.advlib_fmn import FMNAdvLib
 from secmlt.adv.evasion.advlib_attacks.advlib_pgd import PGDAdvLib
 from secmlt.adv.evasion.base_evasion_attack import BaseEvasionAttack
+from secmlt.adv.evasion.boundary_attack import BoundaryAttack
 from secmlt.adv.evasion.cw import CW
 from secmlt.adv.evasion.ddn import DDN
 from secmlt.adv.evasion.deepfool import DeepFool
 from secmlt.adv.evasion.fgsm import FGSM
 from secmlt.adv.evasion.fmn import FMN, FMNNative
 from secmlt.adv.evasion.foolbox_attacks.foolbox_base import BaseFoolboxEvasionAttack
+from secmlt.adv.evasion.foolbox_attacks.foolbox_boundary import BoundaryAttackFoolbox
 from secmlt.adv.evasion.foolbox_attacks.foolbox_fgsm import FGSMFoolbox
 from secmlt.adv.evasion.foolbox_attacks.foolbox_fmn import FMNFoolbox
 from secmlt.adv.evasion.foolbox_attacks.foolbox_pgd import PGDFoolbox
@@ -24,6 +26,7 @@ from secmlt.adv.evasion.perturbation_models import LpPerturbationModels
 from secmlt.adv.evasion.pgd import PGD, PGDNative
 from secmlt.adv.evasion.vat import VAT
 from secmlt.manipulations.manipulation import AdditiveManipulation
+from secmlt.models.pytorch.base_pytorch_nn import BasePyTorchClassifier
 from secmlt.optimization.gradient_processing import GradientProcessing
 from secmlt.optimization.initializer import Initializer
 from secmlt.trackers.trackers import LossTracker
@@ -605,3 +608,42 @@ def test_vat_foolbox_attack(model, data_loader) -> None:
 def test_vat_attack(model, data_loader) -> None:
     attack = VAT(epsilon=0.1, steps=1, backend="foolbox")
     assert isinstance(attack(model, data_loader), DataLoader)
+
+
+@pytest.fixture
+def deterministic_model() -> BasePyTorchClassifier:
+    """Simple deterministic model for decision-based attack tests."""
+    torch.manual_seed(0)
+    net = torch.nn.Sequential(
+        torch.nn.Flatten(),
+        torch.nn.Linear(3 * 32 * 32, 10),
+    )
+    net.eval()
+    return BasePyTorchClassifier(model=net)
+
+
+@pytest.mark.parametrize(
+    "y_target",
+    # y_target=2 chosen because class 2 dominates uniform-noise predictions for
+    # the deterministic_model fixture, making init_attack reliable.
+    [None, 2],
+)
+def test_boundary_attack_foolbox(y_target, deterministic_model, data_loader) -> None:
+    attack = BoundaryAttackFoolbox(steps=100, y_target=y_target)
+    assert isinstance(attack(deterministic_model, data_loader), DataLoader)
+
+
+@pytest.mark.parametrize(
+    "y_target",
+    [None, 2],
+)
+def test_boundary_attack(y_target, deterministic_model, data_loader) -> None:
+    attack = BoundaryAttack(steps=100, y_target=y_target, backend="foolbox")
+    assert isinstance(attack(deterministic_model, data_loader), DataLoader)
+
+
+def test_boundary_attack_only_foolbox_backend() -> None:
+    with pytest.raises(
+        NotImplementedError, match="Unsupported or not-implemented backend"
+    ):
+        BoundaryAttack(steps=100, backend="native")

--- a/src/secmlt/tests/test_attacks.py
+++ b/src/secmlt/tests/test_attacks.py
@@ -36,6 +36,7 @@ from torch.utils.data import DataLoader
 
 PGDEoT = type("PGDEoT", (EoTGradientMixin, PGDNative), {})
 
+
 def _adv_lib_gte(major: int, minor: int, patch: int) -> bool:
     try:
         version_str = importlib.metadata.version("adv-lib")

--- a/src/secmlt/tests/test_attacks.py
+++ b/src/secmlt/tests/test_attacks.py
@@ -23,6 +23,9 @@ from secmlt.adv.evasion.foolbox_attacks.foolbox_fgsm import FGSMFoolbox
 from secmlt.adv.evasion.foolbox_attacks.foolbox_fmn import FMNFoolbox
 from secmlt.adv.evasion.foolbox_attacks.foolbox_hopskipjump import HopSkipJumpFoolbox
 from secmlt.adv.evasion.foolbox_attacks.foolbox_pgd import PGDFoolbox
+from secmlt.adv.evasion.foolbox_attacks.foolbox_saltandpepper import (
+    SaltAndPepperNoiseFoolbox,
+)
 from secmlt.adv.evasion.foolbox_attacks.foolbox_spatial import SpatialAttackFoolbox
 from secmlt.adv.evasion.foolbox_attacks.foolbox_vat import VATFoolbox
 from secmlt.adv.evasion.hopskipjump import HopSkipJump
@@ -33,6 +36,7 @@ from secmlt.adv.evasion.modular_attacks.modular_attack import (
 )
 from secmlt.adv.evasion.perturbation_models import LpPerturbationModels
 from secmlt.adv.evasion.pgd import PGD, PGDNative
+from secmlt.adv.evasion.saltandpepper import SaltAndPepperNoise
 from secmlt.adv.evasion.spatial_attack import SpatialAttack
 from secmlt.adv.evasion.vat import VAT
 from secmlt.manipulations.manipulation import AdditiveManipulation
@@ -828,4 +832,36 @@ def test_additive_noise_perturbation_models() -> None:
     assert AdditiveNoiseFoolbox.get_perturbation_models() == {
         LpPerturbationModels.L2,
         LpPerturbationModels.LINF,
+    }
+
+
+@pytest.mark.parametrize("y_target", [None, 2])
+@pytest.mark.parametrize("across_channels", [True, False])
+def test_saltandpepper_foolbox(
+    y_target, across_channels, deterministic_model, data_loader
+) -> None:
+    attack = SaltAndPepperNoiseFoolbox(
+        steps=10,
+        across_channels=across_channels,
+        y_target=y_target,
+    )
+    assert isinstance(attack(deterministic_model, data_loader), DataLoader)
+
+
+@pytest.mark.parametrize("y_target", [None, 2])
+def test_saltandpepper_attack(y_target, deterministic_model, data_loader) -> None:
+    attack = SaltAndPepperNoise(steps=10, y_target=y_target, backend="foolbox")
+    assert isinstance(attack(deterministic_model, data_loader), DataLoader)
+
+
+def test_saltandpepper_only_foolbox_backend() -> None:
+    with pytest.raises(
+        NotImplementedError, match="Unsupported or not-implemented backend"
+    ):
+        SaltAndPepperNoise(steps=10, backend="native")
+
+
+def test_saltandpepper_perturbation_models() -> None:
+    assert SaltAndPepperNoiseFoolbox.get_perturbation_models() == {
+        LpPerturbationModels.L2,
     }

--- a/src/secmlt/tests/test_attacks.py
+++ b/src/secmlt/tests/test_attacks.py
@@ -19,6 +19,7 @@ from secmlt.adv.evasion.foolbox_attacks.foolbox_fgsm import FGSMFoolbox
 from secmlt.adv.evasion.foolbox_attacks.foolbox_fmn import FMNFoolbox
 from secmlt.adv.evasion.foolbox_attacks.foolbox_hopskipjump import HopSkipJumpFoolbox
 from secmlt.adv.evasion.foolbox_attacks.foolbox_pgd import PGDFoolbox
+from secmlt.adv.evasion.foolbox_attacks.foolbox_spatial import SpatialAttackFoolbox
 from secmlt.adv.evasion.foolbox_attacks.foolbox_vat import VATFoolbox
 from secmlt.adv.evasion.hopskipjump import HopSkipJump
 from secmlt.adv.evasion.modular_attacks.eot_gradient import EoTGradientMixin
@@ -28,6 +29,7 @@ from secmlt.adv.evasion.modular_attacks.modular_attack import (
 )
 from secmlt.adv.evasion.perturbation_models import LpPerturbationModels
 from secmlt.adv.evasion.pgd import PGD, PGDNative
+from secmlt.adv.evasion.spatial_attack import SpatialAttack
 from secmlt.adv.evasion.vat import VAT
 from secmlt.manipulations.manipulation import AdditiveManipulation
 from secmlt.models.pytorch.base_pytorch_nn import BasePyTorchClassifier
@@ -714,3 +716,44 @@ def test_hopskipjump_only_foolbox_backend() -> None:
         NotImplementedError, match="Unsupported or not-implemented backend"
     ):
         HopSkipJump(steps=5, backend="native")
+
+
+@pytest.mark.parametrize("y_target", [None, 2])
+@pytest.mark.parametrize("grid_search", [True, False])
+def test_spatial_attack_foolbox(
+    y_target, grid_search, deterministic_model, data_loader
+) -> None:
+    attack = SpatialAttackFoolbox(
+        max_translation=2,
+        max_rotation=15,
+        num_translations=3,
+        num_rotations=3,
+        grid_search=grid_search,
+        random_steps=5,
+        y_target=y_target,
+    )
+    assert isinstance(attack(deterministic_model, data_loader), DataLoader)
+
+
+@pytest.mark.parametrize("y_target", [None, 2])
+def test_spatial_attack(y_target, deterministic_model, data_loader) -> None:
+    attack = SpatialAttack(
+        max_translation=2,
+        max_rotation=15,
+        num_translations=3,
+        num_rotations=3,
+        y_target=y_target,
+        backend="foolbox",
+    )
+    assert isinstance(attack(deterministic_model, data_loader), DataLoader)
+
+
+def test_spatial_attack_only_foolbox_backend() -> None:
+    with pytest.raises(
+        NotImplementedError, match="Unsupported or not-implemented backend"
+    ):
+        SpatialAttack(backend="native")
+
+
+def test_spatial_attack_no_lp_perturbation_models() -> None:
+    assert SpatialAttackFoolbox.get_perturbation_models() == set()

--- a/src/secmlt/tests/test_attacks.py
+++ b/src/secmlt/tests/test_attacks.py
@@ -9,6 +9,7 @@ from secmlt.adv.evasion.advlib_attacks.advlib_fmn import FMNAdvLib
 from secmlt.adv.evasion.advlib_attacks.advlib_pgd import PGDAdvLib
 from secmlt.adv.evasion.base_evasion_attack import BaseEvasionAttack
 from secmlt.adv.evasion.boundary_attack import BoundaryAttack
+from secmlt.adv.evasion.contrast_reduction import ContrastReduction
 from secmlt.adv.evasion.cw import CW
 from secmlt.adv.evasion.ddn import DDN
 from secmlt.adv.evasion.deepfool import DeepFool
@@ -19,8 +20,12 @@ from secmlt.adv.evasion.foolbox_attacks.foolbox_additive_noise import (
 )
 from secmlt.adv.evasion.foolbox_attacks.foolbox_base import BaseFoolboxEvasionAttack
 from secmlt.adv.evasion.foolbox_attacks.foolbox_boundary import BoundaryAttackFoolbox
+from secmlt.adv.evasion.foolbox_attacks.foolbox_contrast_reduction import (
+    ContrastReductionFoolbox,
+)
 from secmlt.adv.evasion.foolbox_attacks.foolbox_fgsm import FGSMFoolbox
 from secmlt.adv.evasion.foolbox_attacks.foolbox_fmn import FMNFoolbox
+from secmlt.adv.evasion.foolbox_attacks.foolbox_gaussian_blur import GaussianBlurFoolbox
 from secmlt.adv.evasion.foolbox_attacks.foolbox_hopskipjump import HopSkipJumpFoolbox
 from secmlt.adv.evasion.foolbox_attacks.foolbox_pgd import PGDFoolbox
 from secmlt.adv.evasion.foolbox_attacks.foolbox_saltandpepper import (
@@ -28,6 +33,7 @@ from secmlt.adv.evasion.foolbox_attacks.foolbox_saltandpepper import (
 )
 from secmlt.adv.evasion.foolbox_attacks.foolbox_spatial import SpatialAttackFoolbox
 from secmlt.adv.evasion.foolbox_attacks.foolbox_vat import VATFoolbox
+from secmlt.adv.evasion.gaussian_blur import GaussianBlur
 from secmlt.adv.evasion.hopskipjump import HopSkipJump
 from secmlt.adv.evasion.modular_attacks.eot_gradient import EoTGradientMixin
 from secmlt.adv.evasion.modular_attacks.modular_attack import (
@@ -863,5 +869,55 @@ def test_saltandpepper_only_foolbox_backend() -> None:
 
 def test_saltandpepper_perturbation_models() -> None:
     assert SaltAndPepperNoiseFoolbox.get_perturbation_models() == {
+        LpPerturbationModels.L2,
+    }
+
+
+@pytest.mark.parametrize("y_target", [None, 2])
+def test_gaussian_blur_foolbox(y_target, deterministic_model, data_loader) -> None:
+    attack = GaussianBlurFoolbox(steps=20, y_target=y_target)
+    assert isinstance(attack(deterministic_model, data_loader), DataLoader)
+
+
+@pytest.mark.parametrize("y_target", [None, 2])
+def test_gaussian_blur_attack(y_target, deterministic_model, data_loader) -> None:
+    attack = GaussianBlur(steps=20, y_target=y_target, backend="foolbox")
+    assert isinstance(attack(deterministic_model, data_loader), DataLoader)
+
+
+def test_gaussian_blur_only_foolbox_backend() -> None:
+    with pytest.raises(
+        NotImplementedError, match="Unsupported or not-implemented backend"
+    ):
+        GaussianBlur(steps=20, backend="native")
+
+
+def test_gaussian_blur_perturbation_models() -> None:
+    assert GaussianBlurFoolbox.get_perturbation_models() == {LpPerturbationModels.L2}
+
+
+@pytest.mark.parametrize("y_target", [None, 1])
+def test_contrast_reduction_foolbox(y_target, model, data_loader) -> None:
+    attack = ContrastReductionFoolbox(epsilon=0.5, target=0.5, y_target=y_target)
+    assert isinstance(attack(model, data_loader), DataLoader)
+
+
+@pytest.mark.parametrize("y_target", [None, 1])
+def test_contrast_reduction_attack(y_target, model, data_loader) -> None:
+    attack = ContrastReduction(
+        epsilon=0.5, target=0.5, y_target=y_target, backend="foolbox"
+    )
+    assert isinstance(attack(model, data_loader), DataLoader)
+
+
+def test_contrast_reduction_only_foolbox_backend() -> None:
+    with pytest.raises(
+        NotImplementedError, match="Unsupported or not-implemented backend"
+    ):
+        ContrastReduction(epsilon=0.5, backend="native")
+
+
+def test_contrast_reduction_perturbation_models() -> None:
+    assert ContrastReductionFoolbox.get_perturbation_models() == {
         LpPerturbationModels.L2,
     }

--- a/src/secmlt/tests/test_attacks.py
+++ b/src/secmlt/tests/test_attacks.py
@@ -17,8 +17,10 @@ from secmlt.adv.evasion.foolbox_attacks.foolbox_base import BaseFoolboxEvasionAt
 from secmlt.adv.evasion.foolbox_attacks.foolbox_boundary import BoundaryAttackFoolbox
 from secmlt.adv.evasion.foolbox_attacks.foolbox_fgsm import FGSMFoolbox
 from secmlt.adv.evasion.foolbox_attacks.foolbox_fmn import FMNFoolbox
+from secmlt.adv.evasion.foolbox_attacks.foolbox_hopskipjump import HopSkipJumpFoolbox
 from secmlt.adv.evasion.foolbox_attacks.foolbox_pgd import PGDFoolbox
 from secmlt.adv.evasion.foolbox_attacks.foolbox_vat import VATFoolbox
+from secmlt.adv.evasion.hopskipjump import HopSkipJump
 from secmlt.adv.evasion.modular_attacks.eot_gradient import EoTGradientMixin
 from secmlt.adv.evasion.modular_attacks.modular_attack import (
     CE_LOSS,
@@ -668,3 +670,47 @@ def test_boundary_attack_only_foolbox_backend() -> None:
         NotImplementedError, match="Unsupported or not-implemented backend"
     ):
         BoundaryAttack(steps=100, backend="native")
+
+
+@pytest.mark.parametrize("y_target", [None, 2])
+@pytest.mark.parametrize(
+    "perturbation_model",
+    [LpPerturbationModels.L2, LpPerturbationModels.LINF],
+)
+def test_hopskipjump_foolbox(
+    y_target, perturbation_model, deterministic_model, data_loader
+) -> None:
+    attack = HopSkipJumpFoolbox(
+        perturbation_model=perturbation_model,
+        steps=5,
+        initial_gradient_eval_steps=10,
+        max_gradient_eval_steps=20,
+        y_target=y_target,
+    )
+    assert isinstance(attack(deterministic_model, data_loader), DataLoader)
+
+
+@pytest.mark.parametrize("y_target", [None, 2])
+@pytest.mark.parametrize(
+    "perturbation_model",
+    [LpPerturbationModels.L2, LpPerturbationModels.LINF],
+)
+def test_hopskipjump_attack(
+    y_target, perturbation_model, deterministic_model, data_loader
+) -> None:
+    attack = HopSkipJump(
+        perturbation_model=perturbation_model,
+        steps=5,
+        initial_gradient_eval_steps=10,
+        max_gradient_eval_steps=20,
+        y_target=y_target,
+        backend="foolbox",
+    )
+    assert isinstance(attack(deterministic_model, data_loader), DataLoader)
+
+
+def test_hopskipjump_only_foolbox_backend() -> None:
+    with pytest.raises(
+        NotImplementedError, match="Unsupported or not-implemented backend"
+    ):
+        HopSkipJump(steps=5, backend="native")

--- a/src/secmlt/tests/test_attacks.py
+++ b/src/secmlt/tests/test_attacks.py
@@ -2,6 +2,7 @@ import importlib.metadata
 
 import pytest
 import torch
+from secmlt.adv.evasion.additive_noise import AdditiveNoise
 from secmlt.adv.evasion.advlib_attacks.advlib_base import BaseAdvLibEvasionAttack
 from secmlt.adv.evasion.advlib_attacks.advlib_fgsm import FGSMAdvLib
 from secmlt.adv.evasion.advlib_attacks.advlib_fmn import FMNAdvLib
@@ -13,6 +14,9 @@ from secmlt.adv.evasion.ddn import DDN
 from secmlt.adv.evasion.deepfool import DeepFool
 from secmlt.adv.evasion.fgsm import FGSM
 from secmlt.adv.evasion.fmn import FMN, FMNNative
+from secmlt.adv.evasion.foolbox_attacks.foolbox_additive_noise import (
+    AdditiveNoiseFoolbox,
+)
 from secmlt.adv.evasion.foolbox_attacks.foolbox_base import BaseFoolboxEvasionAttack
 from secmlt.adv.evasion.foolbox_attacks.foolbox_boundary import BoundaryAttackFoolbox
 from secmlt.adv.evasion.foolbox_attacks.foolbox_fgsm import FGSMFoolbox
@@ -757,3 +761,71 @@ def test_spatial_attack_only_foolbox_backend() -> None:
 
 def test_spatial_attack_no_lp_perturbation_models() -> None:
     assert SpatialAttackFoolbox.get_perturbation_models() == set()
+
+
+@pytest.mark.parametrize("y_target", [None, 1])
+@pytest.mark.parametrize(
+    ("perturbation_model", "noise_type"),
+    [
+        (LpPerturbationModels.L2, "gaussian"),
+        (LpPerturbationModels.L2, "uniform"),
+        (LpPerturbationModels.LINF, "uniform"),
+    ],
+)
+def test_additive_noise_foolbox(
+    y_target, perturbation_model, noise_type, model, data_loader
+) -> None:
+    attack = AdditiveNoiseFoolbox(
+        epsilon=0.5,
+        perturbation_model=perturbation_model,
+        noise_type=noise_type,
+        y_target=y_target,
+    )
+    assert isinstance(attack(model, data_loader), DataLoader)
+
+
+@pytest.mark.parametrize("y_target", [None, 1])
+@pytest.mark.parametrize(
+    ("perturbation_model", "noise_type"),
+    [
+        (LpPerturbationModels.L2, "gaussian"),
+        (LpPerturbationModels.L2, "uniform"),
+        (LpPerturbationModels.LINF, "uniform"),
+    ],
+)
+def test_additive_noise_attack(
+    y_target, perturbation_model, noise_type, model, data_loader
+) -> None:
+    attack = AdditiveNoise(
+        epsilon=0.5,
+        perturbation_model=perturbation_model,
+        noise_type=noise_type,
+        y_target=y_target,
+        backend="foolbox",
+    )
+    assert isinstance(attack(model, data_loader), DataLoader)
+
+
+def test_additive_noise_only_foolbox_backend() -> None:
+    with pytest.raises(
+        NotImplementedError, match="Unsupported or not-implemented backend"
+    ):
+        AdditiveNoise(epsilon=0.5, backend="native")
+
+
+def test_additive_noise_unsupported_combination() -> None:
+    with pytest.raises(
+        NotImplementedError, match="Unsupported combination of perturbation model"
+    ):
+        AdditiveNoiseFoolbox(
+            epsilon=0.5,
+            perturbation_model=LpPerturbationModels.LINF,
+            noise_type="gaussian",
+        )
+
+
+def test_additive_noise_perturbation_models() -> None:
+    assert AdditiveNoiseFoolbox.get_perturbation_models() == {
+        LpPerturbationModels.L2,
+        LpPerturbationModels.LINF,
+    }

--- a/src/secmlt/tests/test_attacks.py
+++ b/src/secmlt/tests/test_attacks.py
@@ -1,4 +1,3 @@
-import importlib.metadata
 
 import pytest
 import torch

--- a/src/secmlt/tests/test_attacks.py
+++ b/src/secmlt/tests/test_attacks.py
@@ -1,7 +1,6 @@
 import pytest
 import torch
 from secmlt.adv.evasion.advlib_attacks.advlib_base import BaseAdvLibEvasionAttack
-from secmlt.adv.evasion.advlib_attacks.advlib_deepfool import DeepFoolAdvLib
 from secmlt.adv.evasion.advlib_attacks.advlib_fgsm import FGSMAdvLib
 from secmlt.adv.evasion.advlib_attacks.advlib_fmn import FMNAdvLib
 from secmlt.adv.evasion.advlib_attacks.advlib_pgd import PGDAdvLib
@@ -12,10 +11,10 @@ from secmlt.adv.evasion.deepfool import DeepFool
 from secmlt.adv.evasion.fgsm import FGSM
 from secmlt.adv.evasion.fmn import FMN, FMNNative
 from secmlt.adv.evasion.foolbox_attacks.foolbox_base import BaseFoolboxEvasionAttack
-from secmlt.adv.evasion.foolbox_attacks.foolbox_deepfool import DeepFoolFoolbox
 from secmlt.adv.evasion.foolbox_attacks.foolbox_fgsm import FGSMFoolbox
 from secmlt.adv.evasion.foolbox_attacks.foolbox_fmn import FMNFoolbox
 from secmlt.adv.evasion.foolbox_attacks.foolbox_pgd import PGDFoolbox
+from secmlt.adv.evasion.foolbox_attacks.foolbox_vat import VATFoolbox
 from secmlt.adv.evasion.modular_attacks.eot_gradient import EoTGradientMixin
 from secmlt.adv.evasion.modular_attacks.modular_attack import (
     CE_LOSS,
@@ -23,6 +22,7 @@ from secmlt.adv.evasion.modular_attacks.modular_attack import (
 )
 from secmlt.adv.evasion.perturbation_models import LpPerturbationModels
 from secmlt.adv.evasion.pgd import PGD, PGDNative
+from secmlt.adv.evasion.vat import VAT
 from secmlt.manipulations.manipulation import AdditiveManipulation
 from secmlt.optimization.gradient_processing import GradientProcessing
 from secmlt.optimization.initializer import Initializer
@@ -430,9 +430,7 @@ def test_attack_can_return_generator(model, data_loader):
     total_attacked_samples = sum(
         batch_adv.shape[0] for batch_adv, _ in attacked_batches
     )
-    total_labels = sum(
-        batch_labels.shape[0] for _, batch_labels in attacked_batches
-    )
+    total_labels = sum(batch_labels.shape[0] for _, batch_labels in attacked_batches)
     assert total_attacked_samples == len(data_loader.dataset)
     assert total_labels == len(data_loader.dataset)
 
@@ -596,4 +594,14 @@ def test_deepfool_attack(
         overshoot=0.02,
         backend=backend,
     )
+    assert isinstance(attack(model, data_loader), DataLoader)
+
+
+def test_vat_foolbox_attack(model, data_loader) -> None:
+    attack = VATFoolbox(epsilon=0.1, steps=1)
+    assert isinstance(attack(model, data_loader), DataLoader)
+
+
+def test_vat_attack(model, data_loader) -> None:
+    attack = VAT(epsilon=0.1, steps=1, backend="foolbox")
     assert isinstance(attack(model, data_loader), DataLoader)

--- a/src/secmlt/tests/test_attacks.py
+++ b/src/secmlt/tests/test_attacks.py
@@ -1,12 +1,18 @@
 import pytest
 import torch
 from secmlt.adv.evasion.advlib_attacks.advlib_base import BaseAdvLibEvasionAttack
+from secmlt.adv.evasion.advlib_attacks.advlib_fgsm import FGSMAdvLib
+from secmlt.adv.evasion.advlib_attacks.advlib_fmn import FMNAdvLib
 from secmlt.adv.evasion.advlib_attacks.advlib_pgd import PGDAdvLib
 from secmlt.adv.evasion.base_evasion_attack import BaseEvasionAttack
 from secmlt.adv.evasion.ddn import DDN
+from secmlt.adv.evasion.fgsm import FGSM
 from secmlt.adv.evasion.fmn import FMN, FMNNative
 from secmlt.adv.evasion.foolbox_attacks.foolbox_base import BaseFoolboxEvasionAttack
+from secmlt.adv.evasion.foolbox_attacks.foolbox_fgsm import FGSMFoolbox
+from secmlt.adv.evasion.foolbox_attacks.foolbox_fmn import FMNFoolbox
 from secmlt.adv.evasion.foolbox_attacks.foolbox_pgd import PGDFoolbox
+from secmlt.adv.evasion.modular_attacks.eot_gradient import EoTGradientMixin
 from secmlt.adv.evasion.modular_attacks.modular_attack import (
     CE_LOSS,
     ModularEvasionAttack,
@@ -18,10 +24,6 @@ from secmlt.optimization.gradient_processing import GradientProcessing
 from secmlt.optimization.initializer import Initializer
 from secmlt.trackers.trackers import LossTracker
 from torch.utils.data import DataLoader
-
-from src.secmlt.adv.evasion.advlib_attacks.advlib_fmn import FMNAdvLib
-from src.secmlt.adv.evasion.foolbox_attacks.foolbox_fmn import FMNFoolbox
-from src.secmlt.adv.evasion.modular_attacks.eot_gradient import EoTGradientMixin
 
 PGDEoT = type("PGDEoT", (EoTGradientMixin, PGDNative), {})
 
@@ -294,6 +296,82 @@ def test_fmn_attack(
                 perturbation_model=perturbation_model,
                 num_steps=10,
                 step_size=0.1,
+                y_target=y_target,
+                backend=backend,
+            )
+            assert isinstance(attack(model, data_loader), DataLoader)
+
+
+@pytest.mark.parametrize(
+    "y_target",
+    [None, 1],
+)
+def test_fgsm_foolbox_attack(
+    y_target,
+    model,
+    data_loader,
+) -> None:
+    for perturbation_model in LpPerturbationModels.pert_models:
+        if perturbation_model in FGSMFoolbox.get_perturbation_models():
+            attack = FGSMFoolbox(
+                perturbation_model=perturbation_model,
+                epsilon=0.1,
+                y_target=y_target,
+            )
+            assert isinstance(attack(model, data_loader), DataLoader)
+
+
+@pytest.mark.parametrize(
+    "y_target",
+    [None, 1],
+)
+def test_fgsm_advlib_attack(
+    y_target,
+    model,
+    data_loader,
+) -> None:
+    for perturbation_model in LpPerturbationModels.pert_models:
+        if perturbation_model in FGSMAdvLib.get_perturbation_models():
+            attack = FGSMAdvLib(
+                perturbation_model=perturbation_model,
+                epsilon=0.1,
+                y_target=y_target,
+            )
+            assert isinstance(attack(model, data_loader), DataLoader)
+
+
+def test_fgsm_advlib_raises_on_invalid_loss():
+    with pytest.raises(ValueError, match="FGSM AdvLib supports only these losses"):
+        FGSMAdvLib(
+            perturbation_model=LpPerturbationModels.LINF,
+            epsilon=0.1,
+            loss_function="unknown",
+        )
+
+
+@pytest.mark.parametrize(
+    "y_target",
+    [None, 1],
+)
+@pytest.mark.parametrize(
+    ("backend", "perturbation_models_fgsm"),
+    [
+        ("foolbox", FGSMFoolbox.get_perturbation_models()),
+        ("advlib", FGSMAdvLib.get_perturbation_models()),
+    ],
+)
+def test_fgsm_attack(
+    backend,
+    perturbation_models_fgsm,
+    y_target,
+    model,
+    data_loader,
+) -> None:
+    for perturbation_model in LpPerturbationModels.pert_models:
+        if perturbation_model in perturbation_models_fgsm:
+            attack = FGSM(
+                perturbation_model=perturbation_model,
+                epsilon=0.1,
                 y_target=y_target,
                 backend=backend,
             )


### PR DESCRIPTION
This pull request adds several new adversarial attack wrappers and improves integration with the Adversarial Library (`adv_lib`) and Foolbox (`foolbox`) backend. 

### New Attack Implementations

- FGSM - Foolbox + AdvLib
- CW (Carlini-Wagner) - Foolbox + AdvLib
- DeepFool - Foolbox + AdvLib
- VAT (Virtual Adversarial Training) - Foolbox
- Additive Noise - Foolbox
- Boundary Attack - Foolbox
- Contrast Reduction - Foolbox
- Gaussian Blur - Foolbox
- HopSkipJump - Foolbox
- Salt & Pepper - Foolbox
- Spatial Attack - Foolbox


